### PR TITLE
One fix, one improvement, both with tests

### DIFF
--- a/lib/ffaker/lorem_cn.rb
+++ b/lib/ffaker/lorem_cn.rb
@@ -20,13 +20,17 @@ module Faker
     end
 
     def sentences(sentence_count = 3)
-      s = (1..sentence_count).map { sentence }.join(' ')
-      s[-1] = '。'
-      "#{s}"
+      s = (1..sentence_count).map { sentence }
+      def s.to_s
+        result = self.join(' ')
+        result[-1] = '。'
+        result
+      end
+      s
     end
 
     def paragraph(sentence_count = 3)
-      sentences(sentence_count + rand(3))
+      sentences(sentence_count + rand(3)).to_s
     end
 
     def paragraphs(paragraph_count = 3)

--- a/test/test_lorem_cn.rb
+++ b/test/test_lorem_cn.rb
@@ -24,6 +24,14 @@ class TestLoremCN < Test::Unit::TestCase
   def test_sentences
     assert Faker::LoremCN.sentences.length >= 2
   end
+  def test_sentences_is_an_array
+    assert Faker::LoremCN.sentences.class == Array
+  end
+  def test_sentences_via_to_s_produces_string_terminated_with_period
+    string = Faker::LoremCN.sentences.to_s
+    assert string.class == String
+    assert string[-1] == '。'
+  end
     
   def test_words
     assert Faker::LoremCN.words.length >= 2


### PR DESCRIPTION
1. Fixed `Faker::LoremCN.paragraphs` to return an array like `Faker::Lorem.paragraphs` does. It was returning a string created via `Array#to_s`, which is practically useless.
2. Improved `Faker::LoremCN.sentences` to return an array, but preserving behaviour for people treating its result as a string.
