### PR TITLE
Added AddressCA for Canada-specific info

### DIFF
--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -23,6 +23,7 @@ module Faker
 
   autoload :Address,       'ffaker/address'
   autoload :AddressDE,     'ffaker/address_de'
+  autoload :AddressCA,     'ffaker/address_ca'
   autoload :Company,       'ffaker/company'
   autoload :Education,     'ffaker/education'
   autoload :Geolocation,   'ffaker/geolocation'

--- a/lib/ffaker/address_ca.rb
+++ b/lib/ffaker/address_ca.rb
@@ -1,0 +1,30 @@
+module Faker
+  module AddressCA
+    include Faker::Address
+    extend ModuleUtils
+    extend self
+
+    def postal_code
+      Faker.bothify(POSTAL_CODE_FORMATS.rand).upcase
+    end
+
+    def province
+      PROVINCE.rand
+    end
+
+    def province_abbr
+      PROVINCE_ABBRS.rand
+    end
+
+    POSTAL_CODE_FORMATS = k ['?#? #?#']
+
+    PROVINCE = k [
+      'Newfoundland and Labrador', 'Nova Scotia', 'Prince Edward Island',
+      'New Brunswick', 'Quebec', 'Ontario', 'Manitoba', 'Saskatchewan',
+      'Alberta', 'British Columbia', 'Yukon', 'Northwest Territories',
+      'Nunavut'
+    ]
+
+    PROVINCE_ABBRS = k %w(NL NS PE NB QC ON MB SK AB BC YT NT NU)
+  end
+end

--- a/test/test_address_ca.rb
+++ b/test/test_address_ca.rb
@@ -1,0 +1,15 @@
+require 'helper'
+
+class TestAddressCA < Test::Unit::TestCase
+  def test_province
+    assert_match /[ a-z]/, Faker::AddressCA.province
+  end
+
+  def test_province_abbr
+    assert_match /[A-Z][A-Z]/, Faker::AddressCA.province_abbr
+  end
+
+  def test_postal_code
+    assert_match /[A-Z]\d[A-Z]\W\d[A-Z]\d/, Faker::AddressCA.postal_code
+  end
+end


### PR DESCRIPTION
I followed the pattern established with the AddressDE module to provide support for Canadian
- provinces
- province abbreviations
- postal codes

Tests are included.
