### PR TITLE
Support mask array to .numerify .letterify and .bothify

### DIFF
--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -5,20 +5,22 @@ module Faker
 
   extend ModuleUtils
 
- LETTERS = k('a'..'z')
+  LETTERS = k('a'..'z')
 
-  def self.numerify(number_string)
-    number_string.gsub!(/#/) { rand(10).to_s }
-    number_string
+  def self.numerify(*masks)
+    mask = k(masks.flatten).rand
+    mask.gsub!(/#/) { rand(10).to_s }
+    mask
   end
 
-  def self.letterify(letter_string)
-    letter_string.gsub!(/\?/) { LETTERS.rand }
-    letter_string
+  def self.letterify(*masks)
+    mask = k(masks.flatten).rand
+    mask.gsub!(/\?/) { LETTERS.rand }
+    mask
   end
 
-  def self.bothify(string)
-    letterify(numerify(string))
+  def self.bothify(masks)
+    letterify(numerify(masks))
   end
 
   autoload :Address,       'ffaker/address'

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -4,12 +4,24 @@ class TestFaker < Test::Unit::TestCase
   def test_numerify
     assert Faker.numerify('###').match(/\d{3}/)
   end
+  
+  def test_numerify_with_array
+    assert Faker.numerify(['###', '###']).match(/\d{3}/)
+  end
 
   def test_letterify
     assert Faker.letterify('???').match(/[a-z]{3}/)
   end
 
+  def test_letterify_with_array
+    assert Faker.letterify(['???', '???']).match(/[a-z]{3}/)
+  end
+
   def test_bothify
     assert Faker.bothify('???###').match(/[a-z]{3}\d{3}/)
+  end
+
+  def test_bothify
+    assert Faker.bothify(['???###', '???###']).match(/[a-z]{3}\d{3}/)
   end
 end


### PR DESCRIPTION
Support .numerify .letterify and .bothify supports array of masks.

So...

Faker.numerify %w[# ## ###] # => result a string of numbers like '0' until '999'
Faker.letterify %w[?? ??? ????] # => result a string like 'aa' until 'zzzz'
Faker.bothify %w[?# ?## ?###] # => result a string like 'a0' until 'z999'

That's it all, folks!
