### PR TITLE
capitalize first word of sentence, do not lowercase rest of sentence

### DIFF
--- a/lib/ffaker/lorem.rb
+++ b/lib/ffaker/lorem.rb
@@ -14,8 +14,8 @@ module Faker
 
     def sentence(word_count = 4)
       s = words(word_count + rand(6))
+      s[0].capitalize!
       s = s.join(' ')
-      s.capitalize!
       "#{s}."
     end
     


### PR DESCRIPTION
Calling capitalize! on a string capitalizes the first letter and lowercases the rest of the string. This minor fix leaves the original capitalization of the rest of the sentence.

This does not affect Lorem since all the words are lowercase. It does affect HipsterIpsum and DizzleIpsum.

Before: High life tattooed brooklyn banksy 8-bit brunch.

After: High life tattooed Brooklyn Banksy 8-bit brunch.
