### PR TITLE
Fix/address module

### DIFF
--- a/test/test_address.rb
+++ b/test/test_address.rb
@@ -42,19 +42,19 @@ class TestAddress < Test::Unit::TestCase
   end
 
   def test_us_state
-    assert_match /[ a-z]/, Faker::Address.us_state
+    assert_match /[ a-z]/, Faker::AddressUS.state
   end
 
   def test_us_state_abbr
-    assert_match /[A-Z]/, Faker::Address.us_state_abbr
+    assert_match /[A-Z]/, Faker::AddressUS.state_abbr
   end
 
   def test_zip_code
-    assert_match /[0-9]/, Faker::Address.zip_code
+    assert_match /[0-9]/, Faker::AddressUS.zip_code
   end
 
   def test_zip_code_frozen
-    assert Faker::Address.zip_code.frozen? == false
+    assert Faker::AddressUS.zip_code.frozen? == false
   end
 
   def test_neighborhood


### PR DESCRIPTION
Remove deprecate warning:
[zip_code] is deprecated. For US addresses please use the AddressUS
module
