### PR TITLE
Added Countries to Address Module

### DIFF
--- a/lib/ffaker/address.rb
+++ b/lib/ffaker/address.rb
@@ -81,6 +81,9 @@ module Faker
       NEIGHBORHOOD.rand
     end
 
+    def country
+      COUNTRY.rand
+    end
 
     COMPASS_DIRECTIONS = k %w(North East West South)
 
@@ -124,5 +127,52 @@ module Faker
       'Cipriani', 'Brentwood Central', 'Jupiter South/Abacoa', 'Sea Ranch Lakes', 'Schall Circle/Lakeside Green',
       'Olmsted Falls Central', 'South of Lake Shore Blvd', 'Gates Mills North', 'White Oak South of Columbia Pike',
       'Rockville East of Hungerford Dr', 'Cleveland Park']
+
+    COUNTRY = k ["Afghanistan", "Albania", "Algeria", "American Samoa", "Andorra", "Angola", "Anguilla", 
+      "Antigua and Barbuda", "Argentina", "Armenia", "Aruba", "Australia", "Austria", "Azerbaijan", 
+      "Bahamas", "Bahrain", "Bangladesh", "Barbados", "Belarus", "Belgium", "Belize", "Benin", "Bermuda", 
+      "Bhutan", "Bolivia", "Bosnia and Herzegovina", "Botswana", "Bouvet Island", "Brazil", 
+      "British Indian Ocean Territory", "British Virgin Islands", "Brunei", 
+      "Bulgaria", "Burkina Faso", "Burundi", 
+      "Cambodia", "Cameroon", "Canada", "Cape Verde", "Cayman Islands", "Central African Republic", 
+      "Chad", "Chile", "China", "Christmas Island", "Cocos Islands", "Colombia", "Comoros", 
+      "Congo", "Congo", "Cook Islands", "Costa Rica", "Cote d'Ivoire", "Croatia", "Cuba", "Cyprus", 
+      "Czech Republic", 
+      "Denmark", "Djibouti", "Dominica", "Dominican Republic", 
+      "Ecuador", "Egypt", "El Salvador", "Equatorial Guinea", "Eritrea", "Estonia", "Ethiopia", 
+      "Faroe Islands", "Falkland Islands", "Fiji", "Finland", "France", "French Guiana", 
+      "French Polynesia", "French Southern Territories", 
+      "Gabon", "Gambia", "Georgia", "Germany", "Ghana", "Gibraltar", "Greece", "Greenland", "Grenada", 
+      "Guadeloupe", "Guam", "Guatemala", "Guernsey", "Guinea", "Guinea-Bissau", "Guyana", 
+      "Haiti", "Honduras", "Hong Kong", "Hungary", 
+      "Iceland", "India", "Indonesia", "Iran", "Iraq", "Ireland", "Isle of Man", "Israel", "Italy", 
+      "Jamaica", "Japan", "Jersey", "Jordan", 
+      "Kazakhstan", "Kenya", "Kiribati", "Korea", "Korea", "Kuwait", "Kyrgyz Republic", 
+      "Laos", "Latvia", "Lebanon", "Lesotho", "Liberia", 
+      "Libya", "Liechtenstein", "Lithuania", "Luxembourg", 
+      "Macao", "Macedonia", "Madagascar", "Malawi", "Malaysia", "Maldives", "Mali", "Malta", 
+      "Marshall Islands", "Martinique", "Mauritania", "Mauritius", "Mayotte", "Mexico", "Micronesia", "Moldova", 
+      "Monaco", "Mongolia", "Montenegro", "Montserrat", "Morocco", "Mozambique", "Myanmar", 
+      "Namibia", "Nauru", "Nepal", "Netherlands Antilles", "Netherlands", "New Caledonia", "New Zealand", 
+      "Nicaragua", "Niger", "Nigeria", "Niue", "Norfolk Island", "Northern Mariana Islands", "Norway", 
+      "Oman", 
+      "Pakistan", "Palau", "Palestinian Territory", "Panama", "Papua New Guinea", "Paraguay", "Peru", 
+      "Philippines", "Pitcairn Islands", "Poland", "Portugal", "Puerto Rico", 
+      "Qatar", 
+      "Reunion", "Romania", "Russian Federation", "Rwanda", 
+      "St. Barthelemy", "St. Helena", "St. Kitts and Nevis", "St. Lucia", "St. Martin", 
+      "St. Pierre and Miquelon", "St. Vincent and the Grenadines", "Samoa", "San Marino", "Sao Tome and Principe", 
+      "Saudi Arabia", "Senegal", "Serbia", "Seychelles", "Sierra Leone", "Singapore", "Slovakia", 
+      "Slovenia", "Solomon Islands", "Somalia", "South Africa", "South Georgia and South Sandwich Islands",
+      "Spain", "Sri Lanka", "Sudan", "Suriname", "Svalbard & Jan Mayen Islands", "Swaziland", "Sweden", 
+      "Switzerland", "Syrian Arab Republic",
+      "Taiwan", "Tajikistan", "Tanzania", "Thailand", "Timor-Leste", "Togo", "Tokelau", "Tonga", 
+      "Trinidad and Tobago", "Tunisia", "Turkey", "Turkmenistan", "Turks and Caicos Islands", "Tuvalu", 
+      "Uganda", "Ukraine", "United Arab Emirates", "United Kingdom", "United States of America", 
+      "US Minor Outlying Islands", "US Virgin Islands", "Uruguay", "Uzbekistan", 
+      "Vanuatu", "Venezuela", "Vietnam", 
+      "Wallis and Futuna", "Western Sahara", 
+      "Yemen", 
+      "Zambia", "Zimbabwe"]
   end
 end

--- a/test/test_address.rb
+++ b/test/test_address.rb
@@ -60,4 +60,8 @@ class TestAddress < Test::Unit::TestCase
   def test_neighborhood
     assert_match /[ a-z]+/, Faker::Address::neighborhood
   end
+  
+  def test_country
+    assert_match /[ a-z]+/, Faker::Address::country
+  end
 end


### PR DESCRIPTION
ported countries from
"https://github.com/stympy/faker/blob/master/lib/locales/en.yml#L6"

this should 'address' issue #32

added simple "[ a-z]" regex test for countries, similar to what was used
for neighbourhoods.
