### PR TITLE
Change STATE_ABBR to not include territories by default

### DIFF
--- a/lib/ffaker/address_us.rb
+++ b/lib/ffaker/address_us.rb
@@ -16,6 +16,10 @@ module Faker
       STATE_ABBR.rand
     end
 
+    def state_and_territories_abbr
+      STATE_AND_TERRITORIES_ABBR.rand
+    end
+
     ZIP_FORMATS = k ['#####', '#####-####']
 
     STATE = k ['Alabama', 'Alaska', 'Arizona', 'Arkansas',
@@ -29,9 +33,14 @@ module Faker
       'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington',
       'West Virginia', 'Wisconsin', 'Wyoming']
 
-    STATE_ABBR = k %w(AL AK AS AZ AR CA CO CT DE DC FM FL GA GU HI ID IL IN IA
+    STATE_AND_TERRITORIES_ABBR = k %w(AL AK AS AZ AR CA CO CT DE DC FM FL GA GU HI ID IL IN IA
                      KS KY LA ME MH MD MA MI MN MS MO MT NE NV NH NJ NM NY NC
                      ND MP OH OK OR PW PA PR RI SC SD TN TX UT VT VI VA WA WV
                      WI WY AE AA AP)
+
+    STATE_ABBR = k %w(AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA
+                     KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM
+                     NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA
+                     WV WI WY)
   end
 end

--- a/test/test_address_us.rb
+++ b/test/test_address_us.rb
@@ -9,6 +9,10 @@ class TestAddressUSUS < Test::Unit::TestCase
     assert_match /[A-Z]/, Faker::AddressUS.state_abbr
   end
 
+  def test_us_state_and_territories_abbr
+    assert_match /[A-Z]/, Faker::AddressUS.state_and_territories_abbr
+  end
+
   def test_zip_code
     assert_match /[0-9]/, Faker::AddressUS.zip_code
   end


### PR DESCRIPTION
Added on STATE_AND_TERRITORIES_ABBR so that users can include territories if needed.
