### PR TITLE
There are no .uk domains not under SLDs

### DIFF
--- a/lib/ffaker/internet.rb
+++ b/lib/ffaker/internet.rb
@@ -65,6 +65,6 @@ module Faker
     BYTE = k((0..255).to_a.map { |n| n.to_s })
     HOSTS = k %w(gmail.com yahoo.com hotmail.com)
     DISPOSABLE_HOSTS = k %w(mailinator.com suremail.info spamherelots.com binkmail.com safetymail.info)
-    DOMAIN_SUFFIXES = k %w(co.uk com us uk ca biz info name)
+    DOMAIN_SUFFIXES = k %w(co.uk com us ca biz info name)
   end
 end


### PR DESCRIPTION
This was causing problems when trying to validate domains using Domainatrix.parse.
