### PR TITLE
Add boxed_coords to allow user to randomize within a rectangular region

### DIFF
--- a/lib/ffaker/geolocation.rb
+++ b/lib/ffaker/geolocation.rb
@@ -34,8 +34,11 @@ module Faker
       [41.77117,-87.888795], [41.900425,-87.624262], [41.737173,-87.869998]]
 
     def boxed_coords(upper_left, lower_right)
-      [ rand(upper_left[0]..lower_right[0]),
-        rand(upper_left[1]..lower_right[1]) ]
+      latitude_range = [upper_left[0], lower_right[0]].sort
+      longitude_range = [upper_left[1], lower_right[1]].sort
+
+      [ rand(latitude_range[0]..latitude_range[1]),
+        rand(longitude_range[0]..longitude_range[1]) ]
     end
   end
 end

--- a/test/test_geolocation.rb
+++ b/test/test_geolocation.rb
@@ -8,4 +8,25 @@ class TestGeolocation < Test::Unit::TestCase
   def test_lng
     assert_match /[0-9]+/, Faker::Geolocation.lng.to_s
   end
+
+  def test_boxed_coords
+    coords_list = [
+      [[1,1], [3,3]],
+      [[12.3455,23.3434], [34.3434,36.34343]],
+      [[12.3455,23.3434], [10.3434,6.34343]]
+    ]
+
+    coords_list.each do |coords|
+      lat_min = [coords[0][0], coords[1][0]].min
+      lat_max = [coords[0][0], coords[1][0]].max
+      lon_min = [coords[0][1], coords[1][1]].min
+      lon_max = [coords[0][1], coords[1][1]].max
+
+      new_coords = Faker::Geolocation.boxed_coords(coords[0], coords[1])
+
+      assert (lat_min..lat_max).include?new_coords[0]
+      assert (lon_min..lon_max).include?new_coords[1]
+    end
+
+  end
 end


### PR DESCRIPTION
...wer right boundary

This is a simple method to allow the user to supply a rectangular region with an upper_left set of coordinates and a lower right set of coordinates and returning a set within those boundaries.
