### PR TITLE
Added RUT (Chilean Id Code) generator

### DIFF
--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -44,6 +44,8 @@ module Faker
   autoload :HealthcareIpsum, 'ffaker/healthcare_ipsum'
   autoload :HipsterIpsum,    'ffaker/hipster_ipsum'
   autoload :Identification,  'ffaker/identification'
+  autoload :IdentificationES,  'ffaker/identification_es'
+  autoload :IdentificationESCL,  'ffaker/identification_es_cl'
   autoload :Internet,        'ffaker/internet'
   autoload :InternetSE,      'ffaker/internet_se'
   autoload :Job,             'ffaker/job'

--- a/lib/ffaker/identification_es.rb
+++ b/lib/ffaker/identification_es.rb
@@ -1,0 +1,13 @@
+module Faker
+  module IdentificationES
+    extend ModuleUtils
+    extend self
+
+    def gender
+      GENDERS.rand
+    end
+
+    GENDERS = k %w(Hombre Mujer)
+
+  end
+end

--- a/lib/ffaker/identification_es_cl.rb
+++ b/lib/ffaker/identification_es_cl.rb
@@ -1,0 +1,22 @@
+module Faker
+  module IdentificationESCL
+    extend IdentificationES
+    extend self
+
+    # RUT is the Chilean ID, followed by format:  XX.XXX.XXX - Y
+    # http://es.wikipedia.org/wiki/Rol_%C3%9Anico_Tributario
+    #
+    # The last Y is a modulo 11 validation code. In the case the result is 10, it will be replaced by a 'K' character
+    def rut
+      # Rut is gonna be between 1.000.000 and 24.999.999
+      n = Kernel.rand(24000000) + 1000000
+      "#{n}-#{dv(n)}"
+    end
+
+    private
+      def dv(rut)
+        total = rut.to_s.rjust(8,'0').split(//).zip(%w(3 2 7 6 5 4 3 2)).collect{|a,b| a.to_i*b.to_i}.inject(:+)
+        (11 - total % 11).to_s.gsub(/10/,'k').gsub(/11/,'0')
+      end
+  end
+end

--- a/test/test_identification_es.rb
+++ b/test/test_identification_es.rb
@@ -1,0 +1,12 @@
+require 'helper'
+
+class TestFakerIdentificationES < Test::Unit::TestCase
+  def setup
+    @tester = Faker::IdentificationES
+  end
+
+  def test_gender
+    assert_match /(Hombre|Mujer)/, @tester.gender
+  end
+
+end

--- a/test/test_identification_es_cl.rb
+++ b/test/test_identification_es_cl.rb
@@ -1,0 +1,12 @@
+require 'helper'
+
+class TestFakerIdentificationESCL < Test::Unit::TestCase
+  def setup
+    @tester = Faker::IdentificationESCL
+  end
+
+  def test_rut
+    assert_match /\b\d{7,8}\-[k|0-9]/i, @tester.rut
+  end
+
+end


### PR DESCRIPTION
Hi, I've added a Chilean Id generator.
Also I've created `identification_es.rb` that could be a base for any generator to a spanish spoken country, `identification_es_cl.rb` in my case. I think this could be handy for generators only applyable to a specific country (I guess RUT is only valid in Chile)
