### PR TITLE
Colombian Identification

### DIFF
--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -46,7 +46,7 @@ module Faker
   autoload :Identification,  'ffaker/identification'
   autoload :IdentificationES,  'ffaker/identification_es'
   autoload :IdentificationESCL,  'ffaker/identification_es_cl'
-  autoload :IdentificationESCOL,  'ffaker/identification_es_col'
+  autoload :IdentificationESCO,  'ffaker/identification_es_co'
   autoload :Internet,        'ffaker/internet'
   autoload :InternetSE,      'ffaker/internet_se'
   autoload :Job,             'ffaker/job'

--- a/lib/ffaker/identification_es_co.rb
+++ b/lib/ffaker/identification_es_co.rb
@@ -1,5 +1,5 @@
 module Faker
-  module IdentificationESCOL
+  module IdentificationESCO
     include IdentificationES
     extend ModuleUtils
     require "date"
@@ -10,7 +10,7 @@ module Faker
       Faker.numerify("#" * how_many_numbers)
     end
 
-  alias :id :drivers_license
+  alias_method :id, :drivers_license
 
     def driver_license_category
       category = LICENSE_CATEGORY.rand

--- a/test/test_identification_co.rb
+++ b/test/test_identification_co.rb
@@ -1,9 +1,9 @@
 require 'helper'
 
-class TestFakerIdentificationESCOL < Test::Unit::TestCase
+class TestFakerIdentificationESCO < Test::Unit::TestCase
   include Test::Unit::Assertions
   def setup
-    @tester = Faker::IdentificationESCOL
+    @tester = Faker::IdentificationESCO
   end
 
   def test_drivers_license


### PR DESCRIPTION
Colombian identification: the new driver license should be the same as the Colombian ID but for the older ones is not a must, so they can be different, they have the same format 6 to 14 numbers (older ones - new ones) and has the blood type (RH) and an expedition date.
