### PR TITLE
Add Support for Nato Alphabet

### DIFF
--- a/lib/ffaker/nato_alphabet.rb
+++ b/lib/ffaker/nato_alphabet.rb
@@ -23,10 +23,10 @@ module Faker
     end
 
     def callsign
-      callsignify("?-?-#")
+      codify("?-?-#")
     end
 
-    def callsignify(masks)
+    def codify(masks)
       masks.scan(/./).map do |c|
         case c
         when "#" then NUMERIC_CODES[Faker.numerify(c).to_i]

--- a/test/test_nato_alphabet.rb
+++ b/test/test_nato_alphabet.rb
@@ -23,9 +23,9 @@ class TestNato < Test::Unit::TestCase
     assert_match /[A-Z]+-[A-Z]+-[A-Z]+/, @tester.callsign
   end
 
-  def test_callsignify
-    assert_match /[A-Z]+-[A-Z]+-[A-Z]+/, @tester.callsignify("?-?-?")
-    assert_match /[A-Z]+-[A-Z]+-[A-Z]+/, @tester.callsignify("?-#-?")
-    assert_match Faker::NatoAlphabet::STOP_CODE, @tester.callsignify(".")
+  def test_codify
+    assert_match /[A-Z]+-[A-Z]+-[A-Z]+/, @tester.codify("?-?-?")
+    assert_match /[A-Z]+-[A-Z]+-[A-Z]+/, @tester.codify("?-#-?")
+    assert_match Faker::NatoAlphabet::STOP_CODE, @tester.codify(".")
   end
 end


### PR DESCRIPTION
Adds support for the nato alphabet and callsigns.

http://en.wikipedia.org/wiki/NATO_phonetic_alphabet#Letters

For example:

```
Faker::NatoAlphabet.code # => "OSCAR"
Faker::NatoAlphabet.callsign # => "ALPHA-CHARLIE-TANGO"
Faker::NatoAlphabet.callsignify("?-?-#-?") # => "XRAY-FOXTROT-SIX-ROMEO"
```
