### PR TITLE
Add carriage returns to HTMLImpsum line breaks

### DIFF
--- a/lib/ffaker/html_ipsum.rb
+++ b/lib/ffaker/html_ipsum.rb
@@ -91,6 +91,7 @@ module Faker
       end
       s << "</tbody>
       </table>"
+      s.gsub /\n/, "\r\n"
     end
 
     def body
@@ -119,6 +120,7 @@ module Faker
         height: 80px;
       }
       </code></pre>"
+      s.gsub /\n/, "\r\n"
     end
 
     def fancy_string(count = 3, include_breaks = false)


### PR DESCRIPTION
This improves compatibility with specific scenarios especially testing with Capybara. Depending on the driver, carriage returns may get added when entering the text into a textarea. The resulting text then differs from the generated one. By having carriage returns out of the box, no such changes should happen and it is easy to compare input and result.
