### PR TITLE
delete unnecessary option of TestTask

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,6 @@ end
 require 'rake/testtask'
 Rake::TestTask.new do |t|
   t.libs << "test/" << "lib/"
-  t.ruby_opts << "-rhelper"
   t.test_files = FileList['test/test*.rb']
   t.verbose = true
 end


### PR DESCRIPTION
Currently, we require `helper.rb` in two place, by `-r` option and each test file.
- In Ruby 1.9.3 and above, `-r` option is not needed but doesn't affect for any place.
- In Ruby 1.8.7,  `Kernel#require` does not work same such as 1.9.3 and above. For this reason, `helper.rb` is required twice in each test file. and it is the reason why the tests are failed in 1.8.7

So this PR will fix the problem which the specs are failing in 1.8.3.
And even if all the tests are passing, this option is unnecessary since `helper.rb` is required in each test file.
