### PR TITLE
Don't load modules in 'lib/ffaker' dir twice on Ruby18

### DIFF
--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -27,5 +27,7 @@ module Faker
   end
 
   # Load all constants.
-  Dir["#{BASE_LIB_PATH}/ffaker/*rb"].sort.each { |f| require f }
+  Dir["#{BASE_LIB_PATH}/ffaker/*.rb"].sort.each do |f|
+    require "ffaker/#{File.basename(f, '.rb')}"
+  end
 end


### PR DESCRIPTION
This is only an issue in Ruby18, where [a file name is not converted to an absolute path before being inserted into the `$LOADED_FEATURES` collection](http://www.ruby-doc.org/core-1.8.7/Kernel.html#method-i-require).

Some modules that have been split up into sub modules (such as the Address modules, i.e. `lib/ffaker/address_us.rb`) require their base module for dependency purposes.  This makes sense, because it keeps the modules modular and allows them to be used individually.

The block that was requiring all sub-modules in the `lib/ffaker` directory on `lib/ffaker.rb`, however, was using the full system path in it's require statements, and thus some of the classes were getting loaded in twice due to the difference in load path.  This prevents this by making the require statement use a path relative to the gem library.

Before this change, this basically what would occur:

```
require 'ffaker'
# this block fires from lib/ffaker.rb:29
# Dir["#{BASE_LIB_PATH}/ffaker/*rb"].sort.each { |f| require f }
require "/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/address.rb"
require "/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/address_au.rb"
# ... at this point the following happens:
```

Now [this line](https://github.com/EmmanuelOga/ffaker/blob/v1.23.0/lib/ffaker/address_au.rb#L3) requires 'lib/ffaker/address' again with a relative path

---

This was really only noticeable when laoding the gem in Ruby18 as you would get warnings like this:

```
1.8.7-p374 :001 > require 'ffaker'
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/address.rb:93: warning: already initialized constant COMPASS_DIRECTIONS
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/address.rb:95: warning: already initialized constant CITY_PREFIXES
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/address.rb:97: warning: already initialized constant SEC_ADDR
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/identification_es.rb:12: warning: already initialized constant GENDERS
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/internet.rb:67: warning: already initialized constant BYTE
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/internet.rb:68: warning: already initialized constant HOSTS
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/internet.rb:69: warning: already initialized constant DISPOSABLE_HOSTS
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/internet.rb:70: warning: already initialized constant DOMAIN_SUFFIXES
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/name.rb:32: warning: already initialized constant PREFIXES
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/name.rb:33: warning: already initialized constant SUFFIXES
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/unit.rb:42: warning: already initialized constant TIME_UNITS
/Users/batkins/.rvm/gems/ruby-1.8.7-p374@sa-website/gems/ffaker-1.22.1/lib/ffaker/unit.rb:48: warning: already initialized constant TEMPERATURE_UNITS
 => true
```

This change will probably also give the gem a minor boost in speed when being loaded in due to the fact that these classes will no longer get required into memory twice.
