### PR TITLE
Use Rake v10.1 for development because v10.2 requires Ruby19 or higher

### DIFF
--- a/ffaker.gemspec
+++ b/ffaker.gemspec
@@ -286,6 +286,6 @@ Gem::Specification.new do |s|
 
   s.test_files = s.files.select { |path| path =~ /^test\/test_.*\.rb/ }
 
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '~> 10.1.1'
   s.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
Rake version `10.2.0` was released yesterday (March 24th), and requires Ruby19 as the minimum required ruby version.  Since `ffaker` is being tested on Ruby18 on Travis-CI, you have to adjust your that line in your  gemspec to use Rake version `10.1.x` or all Ruby18 tests will error out (because that version of Rake can't be installed).

See [here for an example of this type of failure](https://travis-ci.org/EmmanuelOga/ffaker/jobs/21530514#L38).
