### PR TITLE
Add `Internet#safe_email`

### DIFF
--- a/lib/ffaker/internet.rb
+++ b/lib/ffaker/internet.rb
@@ -19,6 +19,10 @@ module Faker
       "#{user_name(name)}@#{HOSTS.rand}"
     end
 
+    def safe_email(name = nil)
+      [user_name(name), 'example.'+ %w[org com net].shuffle.first].join('@')
+    end
+
     def user_name(name = nil)
       if name
         parts = ArrayUtils.shuffle(name.scan(/\w+/)).join(ArrayUtils.rand(%w(. _)))

--- a/test/test_internet.rb
+++ b/test/test_internet.rb
@@ -23,6 +23,10 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.disposable_email.match(/.+@(mailinator\.com|suremail\.info|spamherelots\.com|binkmail\.com|safetymail\.info)/)
   end
 
+  def test_safe_email
+    assert @tester.safe_email.match(/.+@example.(com|net|org)/)
+  end
+
   def test_user_name
     assert @tester.user_name.match(/[a-z]+((_|\.)[a-z]+)?/)
   end


### PR DESCRIPTION
This adds a `safe_email` method, that creates addresses with `@example.(com|net|org)` domain name to prevent potentially sending email to real people. I believe it is quite useful.

It's basically just a straight copy from the faker gem.
