### PR TITLE
Add support for continental (contiguous) US states.

### DIFF
--- a/lib/ffaker/address_us.rb
+++ b/lib/ffaker/address_us.rb
@@ -25,6 +25,16 @@ module Faker
       STATE_AND_TERRITORIES_ABBR.rand
     end
 
+    def continental_state
+      CONTINENTAL_STATE.rand
+    end
+
+    def continental_state_abbr
+      CONTINENTAL_STATE_ABBR.rand
+    end
+
     ZIP_FORMATS = k ['#####', '#####-####']
+    CONTINENTAL_STATE = k (STATE - ['Hawaii', 'Alaska'])
+    CONTINENTAL_STATE_ABBR = k (STATE_ABBR - ['HI', 'AK'])
   end
 end

--- a/test/test_address_us.rb
+++ b/test/test_address_us.rb
@@ -15,6 +15,14 @@ class TestAddressUSUS < Test::Unit::TestCase
     assert_match /[A-Z]/, Faker::AddressUS.state_and_territories_abbr
   end
 
+  def test_us_continental_state
+    assert_match /[ a-z]/, Faker::AddressUS.continental_state
+  end
+
+  def test_us_continental_state_abbr
+    assert_match /[A-Z]/, Faker::AddressUS.continental_state_abbr
+  end
+
   def test_zip_code
     assert_match /[0-9]/, Faker::AddressUS.zip_code
   end


### PR DESCRIPTION
Useful for shipping-related tests (shipping to continental vs air-mail states).
