### PR TITLE
Improve NameJA

### DIFF
--- a/lib/ffaker/name_ja.rb
+++ b/lib/ffaker/name_ja.rb
@@ -5,10 +5,6 @@ module FFaker
     extend ModuleUtils
     extend self
 
-    def name
-      "#{first_name}#{last_name}"
-    end
-
     def first_name
       FIRST_NAMES.sample
     end
@@ -20,5 +16,7 @@ module FFaker
     def last_first
       "#{last_name}#{first_name}"
     end
+
+    alias_method :name, :last_first
   end
 end

--- a/test/test_name_ja.rb
+++ b/test/test_name_ja.rb
@@ -3,11 +3,42 @@
 require 'helper'
 
 class TestFakerNameJA < Test::Unit::TestCase
+  class << self
+    def startup
+      FFaker::NameJA.const_set(:FIRST_NAMES, %w(あきら フミ 三郎))
+      FFaker::NameJA.const_set(:LAST_NAMES, %w(佐藤 高橋 佐々木))
+    end
+
+    def shutdown
+      FFaker::NameJA.class_eval { remove_const(:FIRST_NAMES) }
+      FFaker::NameJA.class_eval { remove_const(:LAST_NAMES) }
+    end
+  end
+
   def setup
     @tester = FFaker::NameJA
   end
 
+  def test_first_name
+    assert_include(@tester::FIRST_NAMES, @tester.first_name)
+  end
+
+  def test_last_name
+    assert_include(@tester::LAST_NAMES, @tester.last_name)
+  end
+
+  def test_last_first
+    assert_last_first(@tester.last_first)
+  end
+
   def test_name
-    assert @tester.name.length >= 2
+    assert_last_first(@tester.name)
+  end
+
+  private
+
+  def assert_last_first(actual)
+    last_first_regexp = /(#{@tester::LAST_NAMES.join('|')})(#{@tester::FIRST_NAMES.join('|')})/
+    assert_match(last_first_regexp, actual)
   end
 end


### PR DESCRIPTION
##### Changes
* FFaker::NameJA.name generate name in the order of last_name, first_name.
* Add test_first_name, test_last_name and test_last_first.
* test_last_first and test_name examine the order of name.

###### FFaker::NameJA.name generate name in the order of last_name, first_name.

Japanese name is not written in order of first_name, last_name like Korean.
I refer to this commit (https://github.com/ffaker/ffaker/commit/335691c16210904951129e66142725abf3c514f4#diff-9144e4d488890fffa372d862fc110957). 
This commit defined last_first as an alias of name.
But I think name should be an alias of last_first, because it is natural.

###### test_last_first and test_name examine the order of name.
https://github.com/suiyujin/ffaker/blob/improve-japanese-name/test%2Ftest_name_ja.rb#L6-16
This section replaces all data to small data, to avoid slowing down.