### PR TITLE
Vin generator result now does not include I, O or Q letters

### DIFF
--- a/lib/ffaker/vehicle.rb
+++ b/lib/ffaker/vehicle.rb
@@ -11,6 +11,7 @@ module FFaker
       beautiful bright calm dangerous dark dull fast magnetic magnificent majestic melodic metallic
       mundane mute mysterious new pleasant pretty resonant royal slate soft tranquil vibrant weak
     ))
+    VIN_LETTERS = (LETTERS - %w(i o q)).map { |letter| letter.upcase }
 
     def base_color
       FFaker::Color.name
@@ -39,7 +40,7 @@ module FFaker
     end
 
     def vin
-      FFaker.bothify('1#???#####?######').upcase
+      FFaker.bothify('1#???#####?######').upcase.gsub(/[IOQ]/, VIN_LETTERS.sample)
     end
 
     def year

--- a/test/test_vehicle.rb
+++ b/test/test_vehicle.rb
@@ -32,7 +32,7 @@ class TestVehicle < Test::Unit::TestCase
   end
 
   def test_vin
-    assert_match /\A[A-Z0-9]{17}\z/, FFaker::Vehicle.vin
+    assert_match /\A[A-Z0-9&&[^IOQ]]{17}\z/, FFaker::Vehicle.vin
   end
 
   def test_drivetrain


### PR DESCRIPTION
As per: https://en.wikipedia.org/wiki/Vehicle_identification_number

*One consistent element of the VIS is the 10th digit, which is required worldwide to encode the model year of the vehicle. Besides the three letters that are not allowed in the VIN itself (I, O and Q), the letters U and Z and the digit 0 are not used for the model year code. Note that the year code is the model year for the vehicle.*

There's more work to do to ensure that generated VIN codes are valid and not only "format valid".