### PR TITLE
Use HTTPS endpoint of robohash.org

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -480,7 +480,7 @@
 
 | Method | Example |
 | ------ | ------- |
-| `image` | http://robohash.org/pariaturvoluptasperferendis.png?size=300x300, http://robohash.org/solutaiuremodi.png?size=300x300, http://robohash.org/adipisciestet.png?size=300x300 |
+| `image` | https://robohash.org/pariaturvoluptasperferendis.png?size=300x300, https://robohash.org/solutaiuremodi.png?size=300x300, https://robohash.org/adipisciestet.png?size=300x300 |
 
 ## FFaker::Lorem
 

--- a/lib/ffaker/avatar.rb
+++ b/lib/ffaker/avatar.rb
@@ -2,9 +2,8 @@
 
 module FFaker
   module Avatar
-    
     extend ModuleUtils
-  	extend self
+    extend self
 
     SUPPORTED_FORMATS = %w(png jpg bmp)
 
@@ -13,8 +12,7 @@ module FFaker
       raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)
       raise ArgumentError, "Not a supported background number. Choose eather 1 or 2" unless (bgset.nil? or (1..2).include?(bgset.to_i))
       slug ||= FFaker::Lorem.words.join
-      "http://robohash.org/#{slug}.#{format}?size=#{size}#{'&bgset=bg' + bgset.to_s unless bgset.nil?}"
+      "https://robohash.org/#{slug}.#{format}?size=#{size}#{'&bgset=bg' + bgset.to_s unless bgset.nil?}"
     end
-    
   end
 end

--- a/test/test_avatar.rb
+++ b/test/test_avatar.rb
@@ -1,22 +1,23 @@
 require 'helper'
 
 class TestAvatar < Test::Unit::TestCase
+  ROBOHASH = 'https://robohash.org'
+
   def setup
     @tester = FFaker::Avatar
   end
 
   def test_avatar
-    assert_match(/\Ahttp:\/\/robohash\.org\/.+\.png\?size=300x300\z/,
+    assert_match(/\Ahttps:\/\/robohash\.org\/.+\.png\?size=300x300\z/,
                  @tester.image)
   end
 
   def test_avatar_with_param
-    assert_equal('http://robohash.org/faker.png?size=300x300',
-                 @tester.image('faker'))
+    assert_equal("#{ROBOHASH}/faker.png?size=300x300", @tester.image('faker'))
   end
 
   def test_avatar_with_correct_size
-    assert_equal('http://robohash.org/faker.png?size=150x320',
+    assert_equal("#{ROBOHASH}/faker.png?size=150x320",
                  @tester.image('faker', '150x320'))
   end
 
@@ -27,7 +28,7 @@ class TestAvatar < Test::Unit::TestCase
   end
 
   def test_avatar_with_supported_format
-    assert_equal('http://robohash.org/faker.jpg?size=300x300',
+    assert_equal("#{ROBOHASH}/faker.jpg?size=300x300",
                  @tester.image('faker', '300x300', 'jpg'))
   end
 
@@ -38,7 +39,7 @@ class TestAvatar < Test::Unit::TestCase
   end
 
   def test_avatar_with_correct_background
-    assert_equal('http://robohash.org/faker.png?size=300x300&bgset=bg1',
+    assert_equal("#{ROBOHASH}/faker.png?size=300x300&bgset=bg1",
                  @tester.image('faker', '300x300', 'png', '1'))
   end
 


### PR DESCRIPTION
HTTP endpoint of Robohash was redirecting to HTTPS.
`open-uri` doesn't automatically follow redirects:

```
irb(main):001:0> require "open-uri"
=> true
irb(main):002:0> open("http://robohash.org/test")
RuntimeError: redirection forbidden: http://robohash.org/test -> https://robohash.org/test
irb(main):003:0> open("https://robohash.org/test")
^[[D=> #<Tempfile:/var/folders/bd/09v89b6j65g0k05wf0rsct5m0000gn/T/open-uri20151102-73867-1j19io5>
```