### PR TITLE
US phone exchange codes follow area code rules

### DIFF
--- a/lib/ffaker/phone_number.rb
+++ b/lib/ffaker/phone_number.rb
@@ -7,22 +7,22 @@ module FFaker
 
     def phone_number
       FFaker.numerify case rand(20)
-                      when      0 then "#{area_code}-###-#### x#####"
-                      when      1 then "#{area_code}-###-#### x####"
-                      when      2 then "#{area_code}-###-#### x###"
-                      when 3..4 then "#{area_code}-###-####"
-                      when      5 then "#{area_code}.###.#### x#####"
-                      when      6 then "#{area_code}.###.#### x####"
-                      when      7 then "#{area_code}.###.#### x###"
-                      when 8..9 then "#{area_code}.###.####"
-                      when     10 then "(#{area_code})###-#### x#####"
-                      when     11 then "(#{area_code})###-#### x####"
-                      when     12 then "(#{area_code})###-#### x###"
-                      when 13..14 then "(#{area_code})###-####"
-                      when     15 then "1-#{area_code}-###-#### x#####"
-                      when     16 then "1-#{area_code}-###-#### x####"
-                      when     17 then "1-#{area_code}-###-#### x###"
-                      when 18..19 then "1-#{area_code}-###-####"
+                      when      0 then "#{area_code}-#{exchange_code}-#### x#####"
+                      when      1 then "#{area_code}-#{exchange_code}-#### x####"
+                      when      2 then "#{area_code}-#{exchange_code}-#### x###"
+                      when 3..4 then "#{area_code}-#{exchange_code}-####"
+                      when      5 then "#{area_code}.#{exchange_code}.#### x#####"
+                      when      6 then "#{area_code}.#{exchange_code}.#### x####"
+                      when      7 then "#{area_code}.#{exchange_code}.#### x###"
+                      when 8..9 then "#{area_code}.#{exchange_code}.####"
+                      when     10 then "(#{area_code})#{exchange_code}-#### x#####"
+                      when     11 then "(#{area_code})#{exchange_code}-#### x####"
+                      when     12 then "(#{area_code})#{exchange_code}-#### x###"
+                      when 13..14 then "(#{area_code})#{exchange_code}-####"
+                      when     15 then "1-#{area_code}-#{exchange_code}-#### x#####"
+                      when     16 then "1-#{area_code}-#{exchange_code}-#### x####"
+                      when     17 then "1-#{area_code}-#{exchange_code}-#### x###"
+                      when 18..19 then "1-#{area_code}-#{exchange_code}-####"
       end
     end
 
@@ -36,8 +36,15 @@ module FFaker
       end
     end
 
+    def exchange_code
+      # The North American Numbering Plan (NANP) does not permit the digits 0
+      # and 1 as the leading digit of the exchange code.
+      # https://en.wikipedia.org/wiki/North_American_Numbering_Plan#Numbering_system
+      area_code
+    end
+
     def short_phone_number
-      FFaker.numerify("#{area_code}-###-####")
+      FFaker.numerify("#{area_code}-#{exchange_code}-####")
     end
 
     def imei(serial_number = nil)

--- a/test/test_phone_number.rb
+++ b/test/test_phone_number.rb
@@ -12,6 +12,11 @@ class TestPhoneNumer < Test::Unit::TestCase
     assert_match /\A\d{3}\z/, FFaker::PhoneNumber.area_code.to_s
   end
 
+  def test_exchange_code
+    assert_not_match /\A\d11\z/, FFaker::PhoneNumber.exchange_code.to_s
+    assert_match /\A\d{3}\z/, FFaker::PhoneNumber.exchange_code.to_s
+  end
+
   def test_short_phone_number
     assert_match /\A\d{3}-\d{3}-\d{4}\z/, FFaker::PhoneNumber.short_phone_number
   end


### PR DESCRIPTION
US exchange codes have to follow the same rules as area codes: https://en.wikipedia.org/wiki/North_American_Numbering_Plan#Numbering_system. This PR makes that change.

I utilized the existing `area_code` generator, but let me know if you want me re-factor further. I also have a regex that has all of this phone logic built in that I can add to the specs. Let me know.