### PR TITLE
Add missing special characters to NameBR test_name regex

### DIFF
--- a/test/test_name_br.rb
+++ b/test/test_name_br.rb
@@ -8,7 +8,7 @@ class TestFakerNameBR < Test::Unit::TestCase
   end
 
   def test_name
-    assert_match(/\A[a-zA-ZéúôóíáÍã\s]+\z/, @tester.name)
+    assert_match(/\A[a-zA-ZáâãéêíóôúüÂÁÉÊÍÓÔÚç\s]+\z/, @tester.name)
   end
 
   def test_name_with_prefix


### PR DESCRIPTION
This PR improves the regex for NameBR tests.

The previous regex: `/\A[a-zA-ZéúôóíáÍã\s]+\z/` wasn't matching all possible special characters available in the list of possible BR names.

Names like 
- Constança Moraes
- Érica Batista
- Éris Sales

Were making the build fail randomly.