### PR TITLE
Add IdentificationBR generator

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -47,6 +47,7 @@
  * [FFaker::HipsterIpsum](#ffakerhipsteripsum)
  * [FFaker::HTMLIpsum](#ffakerhtmlipsum)
  * [FFaker::Identification](#ffakeridentification)
+ * [FFaker::IdentificationBR](#ffakeridentificationbr)
  * [FFaker::IdentificationES](#ffakeridentificationes)
  * [FFaker::IdentificationESCL](#ffakeridentificationescl)
  * [FFaker::IdentificationESCO](#ffakeridentificationesco)
@@ -876,6 +877,15 @@
 | `ethnicity` | Caucasian, African American, Caucasian |
 | `gender` | Male, Male, Female |
 | `ssn` | 320-20-0826, 415-08-7633, 407-93-9239 |
+
+## FFaker::IdentificationBR
+
+| Method | Example |
+| ------ | ------- |
+| `cpf` | 91231683128, 51766257319, 82418015001 |
+| `pretty_cpf` | 837.822.952-77, 462.765.824-00, 695.249.097-79 |
+| `rg` | 067708061, 484333994, 793870281 |
+| `gender` | Feminino, Masculino, Feminino |
 
 ## FFaker::IdentificationES
 

--- a/lib/ffaker/identification_br.rb
+++ b/lib/ffaker/identification_br.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+
+module FFaker
+  module IdentificationBR
+    extend ModuleUtils
+    extend self
+
+    GENDERS = %w(Feminino Masculino).freeze
+
+    def cpf
+      FFaker.numerify('###########')
+    end
+
+    def pretty_cpf
+      FFaker.numerify('###.###.###-##')
+    end
+
+    def rg
+      FFaker.numerify('#########')
+    end
+
+    def pretty_rg
+      FFaker.numerify('###.###.###')
+    end
+
+    def gender
+      GENDERS.sample
+    end
+  end
+end

--- a/test/test_identification_br.rb
+++ b/test/test_identification_br.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+require 'helper'
+
+class TestFakerIdentificationBR < Test::Unit::TestCase
+  def setup
+    @tester = FFaker::IdentificationBR
+  end
+
+  def test_cpf
+    assert_match(/\A\d{11}\z/, @tester.cpf)
+  end
+
+  def test_pretty_cpf
+    assert_match(/\A\d{3}.\d{3}.\d{3}-\d{2}\z/, @tester.pretty_cpf)
+  end
+
+  def test_rg
+    assert_match(/\A\d{9}\z/, @tester.rg)
+  end
+
+  def test_gender
+    assert_match(/\A(Feminino|Masculino)\z/, @tester.gender)
+  end
+end


### PR DESCRIPTION
This PR adds a `IdentificationBR` generator with [CPF number](https://en.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas), [RG number](https://en.wikipedia.org/wiki/Brazilian_identity_card) and gender.

## FFaker::IdentificationBR

| Method | Example |
| ------ | ------- |
| `cpf` | 91231683128, 51766257319, 82418015001 |
| `pretty_cpf` | 837.822.952-77, 462.765.824-00, 695.249.097-79 |
| `rg` | 067708061, 484333994, 793870281 |
| `gender` | Masculino, Feminino, Masculino |
