### PR TITLE
Prevent time generator to generate time with minutes equals to 60

### DIFF
--- a/lib/ffaker/time.rb
+++ b/lib/ffaker/time.rb
@@ -31,7 +31,7 @@ module FFaker
 
     def datetime(params = {})
       hours = params[:hours] || (rand * 12).ceil
-      minutes = params[:minutes] || (rand * 60).ceil
+      minutes = params[:minutes] || (rand * 59).ceil
       date(params.merge(hours: hours, minutes: minutes))
     end
   end


### PR DESCRIPTION
This PR fix in an issue that could happen with ```FFaker::Time``` generator.

Sometimes this line:

```ruby
minutes = params[:minutes] || (rand * 60).ceil
```

Would allow the generation of minutes equals to 60 and that would end up throwing an ```ArgumentError: argument out of range```when generating dates at this line here:

```ruby
series = [date = ::Time.local(year, month, day, hours, minutes)]
```

## PS: issue with the failing build is addressed on this other PR: #266 ##