### PR TITLE
Swap test_address_ch_de.rb and test_address_ch_fr.rb contents to correctly match filename.

### DIFF
--- a/test/test_address_ch_de.rb
+++ b/test/test_address_ch_de.rb
@@ -2,8 +2,8 @@
 
 require 'helper'
 
-class TestAddressCHFR < Test::Unit::TestCase
-  def test_ch_fr_canton
-    assert_match /\A[- a-zàâäèéêëîïôœùûüÿç]+\z/i, FFaker::AddressCHFR.canton
+class TestAddressCHDE < Test::Unit::TestCase
+  def test_ch_de_canton
+    assert_match(/\A[-. a-zæøåü]+\z/i, FFaker::AddressCHDE.canton)
   end
 end

--- a/test/test_address_ch_fr.rb
+++ b/test/test_address_ch_fr.rb
@@ -2,8 +2,8 @@
 
 require 'helper'
 
-class TestAddressCHDE < Test::Unit::TestCase
-  def test_ch_de_canton
-    assert_match(/\A[-. a-zæøåü]+\z/i, FFaker::AddressCHDE.canton)
+class TestAddressCHFR < Test::Unit::TestCase
+  def test_ch_fr_canton
+    assert_match /\A[- a-zàâäèéêëîïôœùûüÿç]+\z/i, FFaker::AddressCHFR.canton
   end
 end

--- a/test/test_address_ch_fr.rb
+++ b/test/test_address_ch_fr.rb
@@ -4,6 +4,6 @@ require 'helper'
 
 class TestAddressCHFR < Test::Unit::TestCase
   def test_ch_fr_canton
-    assert_match /\A[- a-zàâäèéêëîïôœùûüÿç]+\z/i, FFaker::AddressCHFR.canton
+    assert_match(/\A[- a-zàâäèéêëîïôœùûüÿç]+\z/i, FFaker::AddressCHFR.canton)
   end
 end


### PR DESCRIPTION
While working on something else today, I found that `test_address_ch_de.rb` is testing `AddressCHFR` and `test_address_ch_fr.rb` is testing `AddressCHDE`. This pull swaps their contents.