### PR TITLE
Add html_safe_name and html_safe_last_name

### DIFF
--- a/lib/ffaker/name.rb
+++ b/lib/ffaker/name.rb
@@ -16,6 +16,10 @@ module FFaker
       "#{first_name} #{last_name}"
     end
 
+    def html_safe_name
+      "#{first_name} #{html_safe_last_name}"
+    end
+
     def name_with_prefix
       [
         female_name_with_prefix,
@@ -75,6 +79,13 @@ module FFaker
 
     def last_name
       LAST_NAMES.sample
+    end
+
+    def html_safe_last_name
+      loop do
+        t = LAST_NAMES.sample
+        return t unless t.include? "'"
+      end
     end
 
     def prefix

--- a/test/test_name.rb
+++ b/test/test_name.rb
@@ -11,6 +11,10 @@ class TestFakerName < Test::Unit::TestCase
     assert_match(/(\w+\.? ?){2,3}/, @tester.name)
   end
 
+  def test_html_safe_name
+    assert_match(/(\w+\.? ?){2,3}/, @tester.html_safe_name)
+  end
+
   def test_name_with_prefix
     prefix, name, last_name = @tester.name_with_prefix.split(/\s+/)
     assert_include(@tester::PREFIXES, prefix)
@@ -91,6 +95,10 @@ class TestFakerName < Test::Unit::TestCase
 
   def test_last_name
     assert_include(@tester::LAST_NAMES, @tester.last_name)
+  end
+
+  def test_html_safe_last_name
+    assert_include(@tester::LAST_NAMES, @tester.html_safe_last_name)
   end
 
   def test_prefix


### PR DESCRIPTION
Guarantees returned names don’t have an apostrophe, which often breaks controller and view specs because they get escaped to &#39;. The return on test coverage for apostrophed names in this scenario is negligible.