### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ and then
 
     require 'ffaker'
 
+## Ruby  1.8.7
+
+FFaker 1.31.0 is the last version that works with legacy Ruby versions. This version is no longer supported; recent releases will only target recent Ruby versions (See [our Travis file](https://github.com/ffaker/ffaker/blob/master/.travis.yml) for the supported Ruby versions).
+
+```
+gem 'ffaker', '1.31.0'
+```
+
+Finally, you'll have to use the Faker class (v1) instead of FFaker (v2 and later).
+
 ## Why ffaker?
 
 ffaker is a fork of faker, and was initially written in an effort to speed up


### PR DESCRIPTION
As on rubygems.org the Ruby version is not correctly set and allow a Ruby 1.8.7 developer to install an incompatible version, the README.md states now what version of the gem needs to be installed in order to work properly.
