### PR TITLE
AddressAU#time_zone always returns AU time zone and optionally takes state.

### DIFF
--- a/lib/ffaker/address_au.rb
+++ b/lib/ffaker/address_au.rb
@@ -75,6 +75,16 @@ module FFaker
       }
     }.freeze
     POSTCODE = SUBURB.inject({}) { |h, (s_abbr, postcode_suburb_map)| h.update(s_abbr => postcode_suburb_map.keys) }
+    TIME_ZONE = {
+      'ACT' => 'Australia/Canberra',
+      'NT' => 'Australia/Darwin',
+      'SA' => 'Australia/Adelaide',
+      'WA' => 'Australia/Perth',
+      'NSW' => 'Australia/Sydney',
+      'QLD' => 'Australia/Brisbane',
+      'VIC' => 'Australia/Melbourne',
+      'TAS' => 'Australia/Hobart'
+    }.freeze
 
     def postcode(st_abbr = nil)
       st_abbr ||= state_abbr
@@ -98,6 +108,14 @@ module FFaker
     def full_address(st_abbr = nil)
       st_abbr ||= state_abbr
       "#{FFaker::Address.street_address}, #{suburb(st_abbr)} #{st_abbr} #{postcode}"
+    end
+
+    def time_zone(st_abbr = nil)
+      if st_abbr
+        TIME_ZONE[st_abbr]
+      else
+        TIME_ZONE.values.sample
+      end
     end
   end
 end

--- a/lib/ffaker/data/address/time_zone
+++ b/lib/ffaker/data/address/time_zone
@@ -108,9 +108,11 @@ Asia/Seoul
 Asia/Tokyo
 Asia/Yakutsk
 Australia/Darwin
+Australia/Canberra
 Australia/Adelaide
 Australia/Melbourne
 Australia/Sydney
+Australia/Perth
 Australia/Brisbane
 Australia/Hobart
 Asia/Vladivostok

--- a/test/test_address_au.rb
+++ b/test/test_address_au.rb
@@ -65,4 +65,15 @@ class TestAddressAU < Test::Unit::TestCase
       assert_deterministic { FFaker::AddressAU.full_address(st_abbr) }
     end
   end
+
+  def test_time_zone
+    assert_includes(FFaker::AddressAU::TIME_ZONE.values, FFaker::AddressAU.time_zone)
+  end
+
+  def test_time_zone_with_states
+    FFaker::AddressAU::STATE_ABBR.each do |st_abbr|
+      assert_includes(FFaker::AddressAU::TIME_ZONE.values, FFaker::AddressAU.time_zone)
+      assert_deterministic { FFaker::AddressAU.postcode(st_abbr) }
+    end
+  end
 end


### PR DESCRIPTION
Patches `AddressAU#time_zone` to behave similar to `AddressAU#full_address` and `AddressAU#suburb`.

Randomly returns an AU time zone without any arguments:

``` ruby
FFaker::AddressAU.time_zone # => "Australia/Brisbane"
```

Always returns the corresponding time zone for the capital city of the given State:

``` ruby
FFaker::AddressAU.time_zone("QLD") # => "Australia/Brisbane"
```

Our test suite makes extensive use of FFaker to build fake data and once we randomly generate a state we scope the suburb, postcode, and time zone to the state.

Any feedback welcome. 