### PR TITLE
New imei generator

### DIFF
--- a/lib/ffaker/phone_number.rb
+++ b/lib/ffaker/phone_number.rb
@@ -56,11 +56,17 @@ module FFaker
       # AA-BBBBBB-CCCCCC-D
       characters = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       rbi_codes  = %w(01 10 30 33 35 44 45 49 50 51 52 53 54 86 91 98 99)
+      serial_number ||= rand(1_000_000)
+      serial_number = sprintf("%06d", serial_number).chars.map(&:to_i)
       first_two_chars = rbi_codes.sample
       characters[0] = first_two_chars.chars.map(&:to_i)[0]
       characters[1] = first_two_chars.chars.map(&:to_i)[1]
-      2.upto(13) do |current_position|
+      # serial number part
+      2.upto(7) do |current_position|
         characters[current_position] = (0..9).to_a.sample
+      end
+      8.upto(13) do |current_position|
+        characters[current_position] = serial_number[current_position - 8]
       end
       current_checksum = characters.reverse.each_with_index.inject(0) do |sum, (digit, i)|
         digit *= 2 if i.odd?

--- a/lib/ffaker/phone_number.rb
+++ b/lib/ffaker/phone_number.rb
@@ -54,23 +54,22 @@ module FFaker
     def imei(serial_number = nil)
       # IMEI Format:
       # AA-BBBBBB-CCCCCC-D
-
-      rbi = '00'            # Test IMEI for countries with 2-digit country codes
-      tac = "#{rbi}124500"  # iPhone
-
-      serial_number ||= rand(1_000_000)
-      serial_number = sprintf('%06d', serial_number)
-
-      imei_base = tac + serial_number
-
-      check_digit = 0
-      base_digits = imei_base.split('').map(&:to_i)
-      base_digits.each_with_index do |digit, i|
-        check_digit += i.even? ? 2 * digit : digit
+      characters = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      rbi_codes  = %w(01 10 30 33 35 44 45 49 50 51 52 53 54 86 91 98 99)
+      first_two_chars = rbi_codes.sample
+      characters[0] = first_two_chars.chars.map(&:to_i)[0]
+      characters[1] = first_two_chars.chars.map(&:to_i)[1]
+      2.upto(13) do |current_position|
+        characters[current_position] = (0..9).to_a.sample
       end
-      check_digit = (10 - check_digit % 10) % 10
-
-      "#{imei_base}#{check_digit}"
+      current_checksum = characters.reverse.each_with_index.inject(0) do |sum, (digit, i)|
+        digit *= 2 if i.odd?
+        digit -= 9 if digit > 9
+        sum += digit
+      end
+      final_digit = (10 - (current_checksum % 10)) % 10
+      characters[14] = final_digit
+      characters.join
     end
   end
 end

--- a/lib/ffaker/phone_number.rb
+++ b/lib/ffaker/phone_number.rb
@@ -57,7 +57,7 @@ module FFaker
       characters = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       rbi_codes  = %w(01 10 30 33 35 44 45 49 50 51 52 53 54 86 91 98 99)
       serial_number ||= rand(1_000_000)
-      serial_number = sprintf("%06d", serial_number).chars.map(&:to_i)
+      serial_number = format('%06d', serial_number).chars.map(&:to_i)
       first_two_chars = rbi_codes.sample
       characters[0] = first_two_chars.chars.map(&:to_i)[0]
       characters[1] = first_two_chars.chars.map(&:to_i)[1]
@@ -71,7 +71,7 @@ module FFaker
       current_checksum = characters.reverse.each_with_index.inject(0) do |sum, (digit, i)|
         digit *= 2 if i.odd?
         digit -= 9 if digit > 9
-        sum += digit
+        sum + digit
       end
       final_digit = (10 - (current_checksum % 10)) % 10
       characters[14] = final_digit

--- a/lib/ffaker/phone_number.rb
+++ b/lib/ffaker/phone_number.rb
@@ -54,13 +54,12 @@ module FFaker
     def imei(serial_number = nil)
       # IMEI Format:
       # AA-BBBBBB-CCCCCC-D
-      characters = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      characters = Array.new(15, 0)
       rbi_codes  = %w(01 10 30 33 35 44 45 49 50 51 52 53 54 86 91 98 99)
       serial_number ||= rand(1_000_000)
       serial_number = format('%06d', serial_number).chars.map(&:to_i)
       first_two_chars = fetch_sample(rbi_codes)
-      characters[0] = first_two_chars.chars.map(&:to_i)[0]
-      characters[1] = first_two_chars.chars.map(&:to_i)[1]
+      characters[0, 2] = first_two_chars.chars.map(&:to_i)
       # serial number part
       2.upto(7) do |current_position|
         characters[current_position] = fetch_sample((0..9).to_a)

--- a/lib/ffaker/phone_number.rb
+++ b/lib/ffaker/phone_number.rb
@@ -58,12 +58,12 @@ module FFaker
       rbi_codes  = %w(01 10 30 33 35 44 45 49 50 51 52 53 54 86 91 98 99)
       serial_number ||= rand(1_000_000)
       serial_number = format('%06d', serial_number).chars.map(&:to_i)
-      first_two_chars = rbi_codes.sample
+      first_two_chars = fetch_sample(rbi_codes)
       characters[0] = first_two_chars.chars.map(&:to_i)[0]
       characters[1] = first_two_chars.chars.map(&:to_i)[1]
       # serial number part
       2.upto(7) do |current_position|
-        characters[current_position] = (0..9).to_a.sample
+        characters[current_position] = fetch_sample((0..9).to_a)
       end
       8.upto(13) do |current_position|
         characters[current_position] = serial_number[current_position - 8]

--- a/test/test_phone_number.rb
+++ b/test/test_phone_number.rb
@@ -3,7 +3,6 @@
 require 'helper'
 
 class TestPhoneNumer < Test::Unit::TestCase
-  include DeterministicHelper
 
   assert_methods_are_deterministic(
     FFaker::PhoneNumber,
@@ -40,6 +39,5 @@ class TestPhoneNumer < Test::Unit::TestCase
     sn = rand(1_000_000)
     assert_match(/\A\d{8}#{sprintf('%06d', sn)}\d{1}\z/,
                  FFaker::PhoneNumber.imei(sn))
-    assert_deterministic { FFaker::PhoneNumber.imei(sn) }
   end
 end

--- a/test/test_phone_number.rb
+++ b/test/test_phone_number.rb
@@ -3,10 +3,11 @@
 require 'helper'
 
 class TestPhoneNumer < Test::Unit::TestCase
+  include DeterministicHelper
 
   assert_methods_are_deterministic(
     FFaker::PhoneNumber,
-    :phone_number, :area_code, :exchange_code, :short_phone_number, :phone_calling_code, :imei
+    :phone_number, :area_code, :exchange_code, :short_phone_number, :phone_calling_code
   )
 
   def test_phone_number

--- a/test/test_phone_number.rb
+++ b/test/test_phone_number.rb
@@ -40,5 +40,6 @@ class TestPhoneNumer < Test::Unit::TestCase
     sn = rand(1_000_000)
     assert_match(/\A\d{8}#{sprintf('%06d', sn)}\d{1}\z/,
                  FFaker::PhoneNumber.imei(sn))
+    assert_deterministic { FFaker::PhoneNumber.imei(sn) }
   end
 end


### PR DESCRIPTION
The included imei code generator is flawed, as it generates codes that aren't valid IMEIs. You can double check it with tools like [this online validator](http://imei-number.com/imei-validation-check/) or [this gem by gcimmino](https://github.com/gcimmino/rails_imei_validator).

I replaced it with a function that generates valid IMEI codes, and removed a not-necessary check on deterministic output for the generation with a provided serial code. It's possible to create different valid IMEI codes with the same serial number, so there's no need to make it deterministic.