### PR TITLE
Added Polish addresses

### DIFF
--- a/lib/ffaker/address_pl.rb
+++ b/lib/ffaker/address_pl.rb
@@ -58,7 +58,7 @@ module FFaker
     end
 
     def building_number # :nodoc:
-      rand(199) + 1
+      rand(1..199)
     end
 
     def secondary_number # :nodoc:

--- a/lib/ffaker/address_pl.rb
+++ b/lib/ffaker/address_pl.rb
@@ -1,0 +1,85 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+module FFaker
+  # Author Walerian Sobczak <walerian.sobczak@gmail.com> github.com/walerian777
+  # Inspirations:
+  # TERYT registry, available at: http://www.stat.gov.pl/broker/access/index.jspa
+  module AddressPL
+    extend ModuleUtils
+    extend self
+
+    STREET_PREFIXES = %w(al. ul.).freeze
+    SQUARE_PREFIXES = %w(bulwar pasaż plac skwer zaułek).freeze
+
+    # Full Polish address with country name in French (according to Universal Postal Union).
+    def full_address(include_country = false, include_secondary = false)
+      address = "#{street_address(include_secondary)} #{postal_code} #{city}"
+      address = "#{address} POLOGNE" if include_country
+      address
+    end
+
+    def street_address(include_secondary = false)
+      address = "#{street_name} #{building_number}"
+      address = "#{address}#{secondary_number}" if include_secondary
+      address
+    end
+
+    def street_name
+      fetch_sample([street, square])
+    end
+
+    def street
+      "#{street_prefix} #{fetch_sample(STREET)}"
+    end
+
+    def square
+      "#{square_prefix} #{fetch_sample(SQUARE)}"
+    end
+
+    # A voivodeship is an administrative area in Poland - a Polish equivalent of state.
+    def voivodeship
+      fetch_sample(VOIVODESHIP)
+    end
+
+    alias state voivodeship
+    alias province voivodeship
+
+    def voivodeship_abbr
+      fetch_sample(VOIVODESHIP_ABBR)
+    end
+
+    def voivodeship_capital_city
+      fetch_sample(VOIVODESHIP_CAPITAL_CITY)
+    end
+
+    def city
+      fetch_sample(CITY)
+    end
+
+    def building_number # :nodoc:
+      rand(199) + 1
+    end
+
+    def secondary_number # :nodoc:
+      case rand(2)
+      when 0 then " m. #{building_number}"
+      when 1 then "/#{building_number}"
+      end
+    end
+
+    def postal_code
+      FFaker.numerify('##-###')
+    end
+
+    alias zip_code postal_code
+
+    def street_prefix
+      fetch_sample(STREET_PREFIXES)
+    end
+
+    def square_prefix
+      fetch_sample(SQUARE_PREFIXES)
+    end
+  end
+end

--- a/lib/ffaker/data/address_pl/city
+++ b/lib/ffaker/data/address_pl/city
@@ -1,0 +1,916 @@
+Aleksandrów Kujawski
+Aleksandrów Łódzki
+Alwernia
+Andrychów
+Annopol
+Augustów
+Babimost
+Baborów
+Baranów Sandomierski
+Barcin
+Barczewo
+Bardo
+Barlinek
+Bartoszyce
+Barwice
+Bełchatów
+Bełżyce
+Będzin
+Biała
+Biała Podlaska
+Białobrzegi
+Białogard
+Biały Bór
+Białystok
+Biecz
+Bielawa
+Bielsk Podlaski
+Bielsko-Biała
+Bieruń
+Bierutów
+Bieżuń
+Biłgoraj
+Biskupiec
+Bisztynek
+Blachownia
+Błaszki
+Błażowa
+Błonie
+Bobolice
+Bobowa
+Bochnia
+Bodzentyn
+Bogatynia
+Boguszów-Gorce
+Bojanowo
+Bolesławiec
+Bolków
+Borek Wielkopolski
+Borne Sulinowo
+Braniewo
+Brańsk
+Brodnica
+Brok
+Brusy
+Brwinów
+Brzeg
+Brzeg Dolny
+Brzesko
+Brzeszcze
+Brześć Kujawski
+Brzeziny
+Brzostek
+Brzozów
+Buk
+Busko-Zdrój
+Bychawa
+Byczyna
+Bydgoszcz
+Bystrzyca Kłodzka
+Bytom
+Bytów
+Cedynia
+Chełm
+Chełmek
+Chełmno
+Chełmża
+Chęciny
+Chmielnik
+Chocianów
+Chociwel
+Chocz
+Chodecz
+Chodzież
+Chojna
+Chojnice
+Chojnów
+Choroszcz
+Chorzele
+Chorzów
+Choszczno
+Chrzanów
+Ciechanowiec
+Ciechanów
+Ciechocinek
+Cieszanów
+Cieszyn
+Ciężkowice
+Cybinka
+Czaplinek
+Czarna Białostocka
+Czarna Woda
+Czarne
+Czarnków
+Czchów
+Czechowice-Dziedzice
+Czeladź
+Czempiń
+Czerniejewo
+Czersk
+Czerwieńsk
+Czerwionka-Leszczyny
+Częstochowa
+Człopa
+Człuchów
+Czyżew
+Ćmielów
+Daleszyce
+Darłowo
+Dąbie
+Dąbrowa Białostocka
+Dąbrowa Górnicza
+Dąbrowa Tarnowska
+Debrzno
+Dębica
+Dęblin
+Dębno
+Dobczyce
+Dobiegniew
+Dobra
+Dobre Miasto
+Dobrodzień
+Dobrzany
+Dobrzyca
+Dobrzyń nad Wisłą
+Dolsk
+Drawno
+Drawsko Pomorskie
+Drezdenko
+Drobin
+Drohiczyn
+Drzewica
+Dukla
+Duszniki-Zdrój
+Dynów
+Działdowo
+Działoszyce
+Działoszyn
+Dzierzgoń
+Dzierżoniów
+Dziwnów
+Elbląg
+Ełk
+Frampol
+Frombork
+Garwolin
+Gąbin
+Gdańsk
+Gdynia
+Giżycko
+Glinojeck
+Gliwice
+Głogów
+Głogów Małopolski
+Głogówek
+Głowno
+Głubczyce
+Głuchołazy
+Głuszyca
+Gniew
+Gniewkowo
+Gniezno
+Gogolin
+Golczewo
+Goleniów
+Golina
+Golub-Dobrzyń
+Gołańcz
+Gołdap
+Goniądz
+Gorlice
+Gorzów Śląski
+Gorzów Wielkopolski
+Gostynin
+Gostyń
+Gościno
+Gozdnica
+Góra
+Góra Kalwaria
+Górowo Iławeckie
+Górzno
+Grabów nad Prosną
+Grajewo
+Grodków
+Grodzisk Mazowiecki
+Grodzisk Wielkopolski
+Grójec
+Grudziądz
+Grybów
+Gryfice
+Gryfino
+Gryfów Śląski
+Gubin
+Hajnówka
+Halinów
+Hel
+Hrubieszów
+Iława
+Iłowa
+Iłża
+Imielin
+Inowrocław
+Ińsko
+Iwonicz-Zdrój
+Izbica Kujawska
+Jabłonowo Pomorskie
+Janikowo
+Janowiec Wielkopolski
+Janów Lubelski
+Jaraczewo
+Jarocin
+Jarosław
+Jasień
+Jasło
+Jastarnia
+Jastrowie
+Jastrzębie-Zdrój
+Jawor
+Jaworzno
+Jaworzyna Śląska
+Jedlicze
+Jedlina-Zdrój
+Jedwabne
+Jelcz-Laskowice
+Jelenia Góra
+Jeziorany
+Jędrzejów
+Jordanów
+Józefów
+Jutrosin
+Kalety
+Kalisz
+Kalisz Pomorski
+Kalwaria Zebrzydowska
+Kałuszyn
+Kamienna Góra
+Kamień Krajeński
+Kamień Pomorski
+Kamieńsk
+Kańczuga
+Karczew
+Kargowa
+Karlino
+Karpacz
+Kartuzy
+Katowice
+Kazimierz Dolny
+Kazimierza Wielka
+Kąty Wrocławskie
+Kcynia
+Kędzierzyn-Koźle
+Kępice
+Kępno
+Kętrzyn
+Kęty
+Kielce
+Kietrz
+Kisielice
+Kleczew
+Kleszczele
+Kluczbork
+Kłecko
+Kłobuck
+Kłodawa
+Kłodzko
+Knurów
+Knyszyn
+Kobylin
+Kobyłka
+Kock
+Kolbuszowa
+Kolno
+Kolonowskie
+Koluszki
+Kołaczyce
+Koło
+Kołobrzeg
+Koniecpol
+Konin
+Konstancin-Jeziorna
+Konstantynów Łódzki
+Końskie
+Koprzywnica
+Korfantów
+Koronowo
+Korsze
+Kosów Lacki
+Kostrzyn
+Kostrzyn nad Odrą
+Koszalin
+Kościan
+Kościerzyna
+Kowal
+Kowalewo Pomorskie
+Kowary
+Koziegłowy
+Kozienice
+Koźmin Wielkopolski
+Kożuchów
+Kórnik
+Krajenka
+Kraków
+Krapkowice
+Krasnobród
+Krasnystaw
+Kraśnik
+Krobia
+Krosno
+Krosno Odrzańskie
+Krośniewice
+Krotoszyn
+Kruszwica
+Krynica Morska
+Krynica-Zdrój
+Krynki
+Krzanowice
+Krzepice
+Krzeszowice
+Krzywiń
+Krzyż Wielkopolski
+Książ Wielkopolski
+Kudowa-Zdrój
+Kunów
+Kutno
+Kuźnia Raciborska
+Kwidzyn
+Lądek-Zdrój
+Legionowo
+Legnica
+Lesko
+Leszno
+Leśna
+Leśnica
+Lewin Brzeski
+Leżajsk
+Lębork
+Lędziny
+Libiąż
+Lidzbark
+Lidzbark Warmiński
+Limanowa
+Lipiany
+Lipno
+Lipsk
+Lipsko
+Lubaczów
+Lubań
+Lubartów
+Lubawa
+Lubawka
+Lubień Kujawski
+Lubin
+Lublin
+Lubliniec
+Lubniewice
+Lubomierz
+Luboń
+Lubraniec
+Lubsko
+Lubycza Królewska
+Lwówek
+Lwówek Śląski
+Łabiszyn
+Łańcut
+Łapy
+Łasin
+Łask
+Łaskarzew
+Łaszczów
+Łaziska Górne
+Łazy
+Łeba
+Łęczna
+Łęczyca
+Łęknica
+Łobez
+Łobżenica
+Łochów
+Łomianki
+Łomża
+Łosice
+Łowicz
+Łódź
+Łuków
+Maków Mazowiecki
+Maków Podhalański
+Malbork
+Małogoszcz
+Małomice
+Margonin
+Marki
+Maszewo
+Miasteczko Śląskie
+Miastko
+Michałowo
+Miechów
+Miejska Górka
+Mielec
+Mielno
+Mieroszów
+Mieszkowice
+Międzybórz
+Międzychód
+Międzylesie
+Międzyrzec Podlaski
+Międzyrzecz
+Międzyzdroje
+Mikołajki
+Mikołów
+Mikstat
+Milanówek
+Milicz
+Miłakowo
+Miłomłyn
+Miłosław
+Mińsk Mazowiecki
+Mirosławiec
+Mirsk
+Mława
+Młynary
+Modliborzyce
+Mogielnica
+Mogilno
+Mońki
+Morawica
+Morąg
+Mordy
+Moryń
+Mosina
+Mrągowo
+Mrocza
+Mrozy
+Mszana Dolna
+Mszczonów
+Murowana Goślina
+Muszyna
+Mysłowice
+Myszków
+Myszyniec
+Myślenice
+Myślibórz
+Nakło nad Notecią
+Nałęczów
+Namysłów
+Narol
+Nasielsk
+Nekla
+Nidzica
+Niemcza
+Niemodlin
+Niepołomice
+Nieszawa
+Nisko
+Nowa Dęba
+Nowa Ruda
+Nowa Sarzyna
+Nowa Sól
+Nowe
+Nowe Brzesko
+Nowe Miasteczko
+Nowe Miasto Lubawskie
+Nowe Miasto nad Pilicą
+Nowe Skalmierzyce
+Nowe Warpno
+Nowogard
+Nowogrodziec
+Nowogród
+Nowogród Bobrzański
+Nowy Dwór Gdański
+Nowy Dwór Mazowiecki
+Nowy Sącz
+Nowy Staw
+Nowy Targ
+Nowy Tomyśl
+Nowy Wiśnicz
+Nysa
+Oborniki
+Oborniki Śląskie
+Obrzycko
+Odolanów
+Ogrodzieniec
+Okonek
+Olecko
+Olesno
+Oleszyce
+Oleśnica
+Olkusz
+Olsztyn
+Olsztynek
+Olszyna
+Oława
+Opalenica
+Opatów
+Opatówek
+Opoczno
+Opole
+Opole Lubelskie
+Orneta
+Orzesze
+Orzysz
+Osieczna
+Osiek
+Ostrołęka
+Ostroróg
+Ostrowiec Świętokrzyski
+Ostróda
+Ostrów Lubelski
+Ostrów Mazowiecka
+Ostrów Wielkopolski
+Ostrzeszów
+Ośno Lubuskie
+Oświęcim
+Otmuchów
+Otwock
+Ozimek
+Ozorków
+Ożarów
+Ożarów Mazowiecki
+Pabianice
+Paczków
+Pajęczno
+Pakość
+Parczew
+Pasłęk
+Pasym
+Pelplin
+Pełczyce
+Piaseczno
+Piaski
+Piastów
+Piechowice
+Piekary Śląskie
+Pieniężno
+Pieńsk
+Pieszyce
+Pilawa
+Pilica
+Pilzno
+Piła
+Piława Górna
+Pińczów
+Pionki
+Piotrków Kujawski
+Piotrków Trybunalski
+Pisz
+Piwniczna-Zdrój
+Pleszew
+Płock
+Płońsk
+Płoty
+Pniewy
+Pobiedziska
+Poddębice
+Podkowa Leśna
+Pogorzela
+Polanica-Zdrój
+Polanów
+Police
+Polkowice
+Połaniec
+Połczyn-Zdrój
+Poniatowa
+Poniec
+Poręba
+Poznań
+Prabuty
+Praszka
+Prochowice
+Proszowice
+Prószków
+Pruchnik
+Prudnik
+Prusice
+Pruszcz Gdański
+Pruszków
+Przasnysz
+Przecław
+Przedbórz
+Przedecz
+Przemków
+Przemyśl
+Przeworsk
+Przysucha
+Pszczyna
+Pszów
+Puck
+Puławy
+Pułtusk
+Puszczykowo
+Pyrzyce
+Pyskowice
+Pyzdry
+Rabka-Zdrój
+Raciąż
+Racibórz
+Radków
+Radlin
+Radłów
+Radom
+Radomsko
+Radomyśl Wielki
+Radymno
+Radziejów
+Radzionków
+Radzymin
+Radzyń Chełmiński
+Radzyń Podlaski
+Rajgród
+Rakoniewice
+Raszków
+Rawa Mazowiecka
+Rawicz
+Recz
+Reda
+Rejowiec
+Rejowiec Fabryczny
+Resko
+Reszel
+Rogoźno
+Ropczyce
+Różan
+Ruciane-Nida
+Ruda Śląska
+Rudnik nad Sanem
+Rumia
+Rybnik
+Rychwał
+Rydułtowy
+Rydzyna
+Ryglice
+Ryki
+Rymanów
+Ryn
+Rypin
+Rzepin
+Rzeszów
+Rzgów
+Sandomierz
+Sanok
+Sejny
+Serock
+Sędziszów
+Sędziszów Małopolski
+Sępopol
+Sępólno Krajeńskie
+Sianów
+Siechnice
+Siedlce
+Siedliszcze
+Siemianowice Śląskie
+Siemiatycze
+Sieniawa
+Sieradz
+Sieraków
+Sierpc
+Siewierz
+Skalbmierz
+Skała
+Skarszewy
+Skaryszew
+Skarżysko-Kamienna
+Skawina
+Skępe
+Skierniewice
+Skoczów
+Skoki
+Skórcz
+Skwierzyna
+Sława
+Sławków
+Sławno
+Słomniki
+Słubice
+Słupca
+Słupsk
+Sobótka
+Sochaczew
+Sokołów Małopolski
+Sokołów Podlaski
+Sokółka
+Solec Kujawski
+Sompolno
+Sopot
+Sosnowiec
+Sośnicowice
+Stalowa Wola
+Starachowice
+Stargard
+Starogard Gdański
+Stary Sącz
+Staszów
+Stawiski
+Stawiszyn
+Stąporków
+Stepnica
+Stęszew
+Stoczek Łukowski
+Stopnica
+Stronie Śląskie
+Strumień
+Stryków
+Strzegom
+Strzelce Krajeńskie
+Strzelce Opolskie
+Strzelin
+Strzelno
+Strzyżów
+Sucha Beskidzka
+Suchań
+Suchedniów
+Suchowola
+Sulechów
+Sulejów
+Sulejówek
+Sulęcin
+Sulmierzyce
+Sułkowice
+Supraśl
+Suraż
+Susz
+Suwałki
+Swarzędz
+Syców
+Szadek
+Szamocin
+Szamotuły
+Szczawnica
+Szczawno-Zdrój
+Szczebrzeszyn
+Szczecin
+Szczecinek
+Szczekociny
+Szczucin
+Szczuczyn
+Szczyrk
+Szczytna
+Szczytno
+Szepietowo
+Szklarska Poręba
+Szlichtyngowa
+Szprotawa
+Sztum
+Szubin
+Szydłowiec
+Ścinawa
+Ślesin
+Śmigiel
+Śrem
+Środa Śląska
+Środa Wielkopolska
+Świątniki Górne
+Świdnica
+Świdnik
+Świdwin
+Świebodzice
+Świebodzin
+Świecie
+Świeradów-Zdrój
+Świerzawa
+Świętochłowice
+Świnoujście
+Tarczyn
+Tarnobrzeg
+Tarnogród
+Tarnowskie Góry
+Tarnów
+Tczew
+Terespol
+Tłuszcz
+Tolkmicko
+Tomaszów Lubelski
+Tomaszów Mazowiecki
+Toruń
+Torzym
+Toszek
+Trzcianka
+Trzciel
+Trzcińsko-Zdrój
+Trzebiatów
+Trzebinia
+Trzebnica
+Trzemeszno
+Tuchola
+Tuchów
+Tuczno
+Tuliszków
+Turek
+Tuszyn
+Twardogóra
+Tychowo
+Tychy
+Tyczyn
+Tykocin
+Tyszowce
+Ujazd
+Ujście
+Ulanów
+Uniejów
+Urzędów
+Ustka
+Ustroń
+Ustrzyki Dolne
+Wadowice
+Wałbrzych
+Wałcz
+Warka
+Warszawa
+Warta
+Wasilków
+Wąbrzeźno
+Wąchock
+Wągrowiec
+Wąsosz
+Wejherowo
+Węgliniec
+Węgorzewo
+Węgorzyno
+Węgrów
+Wiązów
+Wieleń
+Wielichowo
+Wieliczka
+Wieluń
+Wieruszów
+Więcbork
+Wilamowice
+Wisła
+Witkowo
+Witnica
+Wleń
+Władysławowo
+Włocławek
+Włodawa
+Włoszczowa
+Wodzisław Śląski
+Wojcieszów
+Wojkowice
+Wojnicz
+Wolbórz
+Wolbrom
+Wolin
+Wolsztyn
+Wołczyn
+Wołomin
+Wołów
+Woźniki
+Wrocław
+Wronki
+Września
+Wschowa
+Wyrzysk
+Wysoka
+Wysokie Mazowieckie
+Wyszków
+Wyszogród
+Wyśmierzyce
+Zabłudów
+Zabrze
+Zagórów
+Zagórz
+Zakliczyn
+Zaklików
+Zakopane
+Zakroczym
+Zalewo
+Zambrów
+Zamość
+Zator
+Zawadzkie
+Zawichost
+Zawidów
+Zawiercie
+Ząbki
+Ząbkowice Śląskie
+Zbąszynek
+Zbąszyń
+Zduny
+Zduńska Wola
+Zdzieszowice
+Zelów
+Zgierz
+Zgorzelec
+Zielona Góra
+Zielonka
+Ziębice
+Złocieniec
+Złoczew
+Złotoryja
+Złotów
+Złoty Stok
+Zwierzyniec
+Zwoleń
+Żabno
+Żagań
+Żarki
+Żarów
+Żary
+Żelechów
+Żerków
+Żmigród
+Żnin
+Żory
+Żukowo
+Żuromin
+Żychlin
+Żyrardów
+Żywiec

--- a/lib/ffaker/data/address_pl/square
+++ b/lib/ffaker/data/address_pl/square
@@ -1,0 +1,390 @@
+1 Maja
+11 Pułku
+15 Sierpnia
+16 Dywizji
+18 Stycznia
+1831 Roku
+1905 Roku
+21 Stycznia
+3 Maja
+4 Czerwca 1989 Roku
+Adama Mickiewicza
+Akademicki
+Alfreda Nobla
+Aliantów
+Amfiteatru
+Andersa
+Anielewicza
+Anny Jagiellonki
+Armii Krajowej
+Armii Wojska Polskiego
+Armstronga
+Artylerii Polskiej
+Artystów
+Asnyka
+Axentowicza
+Baczyńskiego
+Bankowy
+Barnima I
+Basztowy
+Bałtycki
+Benedyktyński
+Bernardyński
+Białowąsa
+Biskupa Jana Chrapka
+Bogurodzicy
+Bohaterów Armii Krajowej
+Bohaterów Getta
+Bohaterów II Wojny Światowej
+Bohaterów Nysy
+Bohaterów Warszawy
+Bohaterów Westerplatte
+Bohaterów Września
+Bojowników
+Bolesława Chrobrego
+Bolesława Prusa
+Bolesława Wstydliwego
+Bolesława Śmiałego
+Bożego Ciała
+Bramy Wolińskiej
+Bramy Wrocławskiej
+Broniewskiego
+Browarniany
+Browarowy
+Brygady Pancernej
+Bzowy
+Centralny im. Ronalda Reagana
+Chorążego Starca
+Cichociemnych
+Cichy
+Cieszyński
+Cmentarny
+Cystersów
+Czechowicza
+Czerwca 1976 Roku
+Czesława Niemena
+Czochralskiego
+Czysty
+Defiladowy
+Dietla
+Dobrego Pasterza
+Dominikański
+Drezdeńskiego Pułku Czołgów Średnich
+Drzewny
+Drzymały
+Dworcowy
+Dworzysko
+Dwóch Miast
+Działowy
+Dziecka
+Dzierżonia
+Dzika
+Dół
+Dębowy
+Elizy Orzeszkowej
+Emila Młynarskiego
+Energetyka
+Esperanto
+Europejski
+Ewangelicki
+Fabryczny
+Farny
+Fatimski
+Faustyny
+Festiwalu Muzyki Rockowej
+Floriański
+Franciszkański
+Frankfurcki
+Franklina D. Roosevelta
+Fryderyka Chopina
+Gabriela Narutowicza
+Gałczyńskiego
+Gdański
+gen. bryg. dr. Stanisława Czepielika
+gen. Grota Roweckiego
+gen. Jana Nepomucena Umińskiego
+gen. Józefa Bema
+gen. Józefa Hallera
+gen. Pilota Stanisława Skalskiego
+gen. Stanisława Maczka
+gen. Władysława E. Sikorskiego
+Gimnazjalny
+Grotowskiego
+Grunwaldzki
+Gryfitów
+Grzybowy
+Gwiaździsty
+Górników
+Górnośląski
+Handlowy
+Harcerski
+Henryka Pobożnego
+Henryka Sienkiewicza
+Honorowych Dawców Krwi
+Hołdu Pruskiego
+Hutniczy
+Ignacego Paderewskiego
+im. Króla Kazimierza III Wielkiego
+im. Księcia Władysława
+im. Więźniów Oświęcimia
+Inwalidów
+Jacka Kuronia
+Jagielloński
+Jana Chrzciciela
+Jana Długosza
+Jana Henryka Dąbrowskiego
+Jana III Sobieskiego
+Jana Kasprowicza
+Jana Kazimierza
+Jana Kilińskiego
+Jana Matejki
+Jana Pawła II
+Jana z Głogowa
+Jaroszewicza
+Jaroszka
+Jedności
+Jedności Narodowej
+Jedności Słowiańskiej
+Joachima Lelewela
+Józefa
+Józefa Piłsudskiego
+kard. Stefana Wyszyńskiego
+Karola Brzostowskiego
+Karola Miarki
+Kasztanowy
+Kasztelański
+Kaszubski
+Katedralny
+Katyński
+Kazimierza
+Kazimierza Jagiellończyka
+Kazimierza Pułaskiego
+Kingi
+Klasztorny
+Kochanowskiego
+Kolei Warszawsko-Wiedeńskiej
+Kolejowy
+Kombatantów
+Kompanii Armii Krajowej
+Komuny Paryskiej
+Konfederacji Tyszowieckiej
+Konfederatów Barskich
+Konstytucji 3 Maja
+Korczaka
+Kosynierów
+Koszarowy
+Kotlarza
+Kołodziejskiego
+Kołłątaja
+Kościelny
+Krakowski
+Krasickiego
+Krasińskiego
+Króla Władysława Jagiełły
+ks. Jerzego Popiełuszki
+ks. prof. J. Tischnera
+ks. Ryszarda Rajskiego
+Kupiecki
+Kwiatowy
+Lecha
+Legionów
+Leśny
+Limanowskiego
+Lipowy
+Lotników
+Łagiewnicki
+Łukasińskiego
+Magistracki
+Majdańskiego
+Majora Adama Lazarowicz
+Majora Mieczysława Tarchalskiego
+Mariacki
+Mariański
+Mazurski
+Mechaników
+Medyków
+Miejski
+Mieszka I
+Mongolski
+Monte Cassino
+Młyński
+Najświętszej Maryi Panny
+Nauczycieli Tajnego Nauczania
+Niepodległości
+Niepodległości im. Romana Dmowskiego
+Nieznanego Żołnierza
+Niezłomnych
+Norwida
+Nowy
+NSZZ Solidarność
+Obrońców Pokoju
+Obrońców Warszawy
+Obrońców Westerplatte
+Obrońców Wybrzeża
+Oddziałów Młodzieży Powstańczej
+Odnowy
+Odrodzenia
+Ofiar Getta
+Ofiar Katastrofy Smoleńskiej
+Ofiar Katynia
+Ofiar Niemieckich Hitlerowskich Obozów
+Ofiar Stalinizmu
+Ogrodowy
+Oleandrów
+Opatrzności Bożej
+Orląt Lwowskich
+Orła Białego
+Ostrej Bramy
+Ottona
+Pamięci Narodowej
+Papieski
+Parkowy
+Partyzantów
+Patriotów
+Pałacowy
+Piastowski
+Piastów
+Piechoty
+Pielgrzymów
+Pionierów
+Piotra i Pawła
+Pisarzy Polskich
+Pluty
+Pocztowy
+Pokoju
+Politechniki
+Polonii
+Polskiego Czerwonego Krzyża
+Polskiej Organizacji Wojskowej
+Pomorski
+Poniatowskiego
+Powstań Narodowych
+Powstańców Styczniowych
+Powstańców Warszawskich
+Powstańców Wielkopolskich
+Powstańców Śląskich
+prof. Alfonsa Hoffmanna
+prof. Jana Szyrockiego
+prof. Stefana du Chateau
+Przyjaźni
+Przyjaźni Polsko-Węgierskiej
+Przymierza
+Pułkownika Berka Joselewicza
+Pułku Strzelców Konnych
+Raciborski
+Raczyńskiego
+Ratuszowy
+Reymonta
+Richarda Wagnera
+Rocha
+Rodła
+Romualda Traugutta
+Rotmistrza Witolda Pileckiego
+Rumiankowy
+Rybaków
+Rybny
+Rycerski
+Rynkowy
+Rzeźniczy
+Różany
+Róży Wiatrów
+Saperów
+Skargi
+Skłodowskiej-Curie
+Solidarności
+Solny
+Sportowy
+Sprawiedliwości
+Sprzymierzeńców
+Spółdzielczy
+Spółdzielców
+Srebrny
+Stanisława Moniuszki
+Staromiejski
+Staromłyński
+Staroszkolny
+Starozamkowy
+Staszica
+Stawowy
+Stefana Batorego
+Stefana Czarnieckiego
+Stefana Okrzei
+Straconych
+Straży Pożarnej
+Strzelecki
+Stuligrosza
+Sucharskiego
+Sybiraków
+Synagogi
+Szafranka
+Szarych Szeregów
+Szczepański
+Szkolny
+Szpitalny
+Słonecznikowy
+Słoneczny
+Słowackiego
+Słowiański
+Śląski
+Śniegockich
+Śreniawitów
+św. Ambrożego
+św. Anny
+św. Barbary
+św. Ducha
+św. Floriana
+św. Jakuba
+św. Jakuba Apostoła
+św. Jerzego
+św. Józefa
+św. Katarzyny
+św. Krzysztofa
+św. Krzyża
+św. Maksymiliana Kolbego
+św. Mikołaja
+św. Piotra
+św. Rozalii
+św. Stanisława
+św. Wojciecha
+Świętojański
+Tadeusza Czackiego
+Tadeusza Kotarbińskiego
+Towarzystwa Przyjaciół Dzieci
+Uniwersytecki
+Walecznych
+Warszawski
+Wawrzyńca
+Wałowy
+Westerplatte
+Wielkopolski
+Wileński
+Wilsona
+Wincentego Witosa
+Wiślany
+Wojska Polskiego
+Wolnica
+Wolności
+Wszystkich Świętych
+Wybickiego
+Wyspiańskiego
+Wyzwolenia
+Władysława Łokietka
+Xawerego Dunikowskiego
+Zakopiański
+Zamenhofa
+Zamkowy
+Zawadzkiego
+Zawiszy Czarnego
+Zbawiciela
+Zdrojowy
+Zgody
+Zjednoczenia Narodowego
+Zofii Nałkowskiej
+Związku Nauczycielstwa Polskiego
+Zwycięstwa
+Zygmunta Starego
+Żelazny
+Żeromskiego
+Żołnierza
+Żołnierzy Wyklętych
+Żwirki i Wigury

--- a/lib/ffaker/data/address_pl/street
+++ b/lib/ffaker/data/address_pl/street
@@ -1,0 +1,390 @@
+1 Maja
+11 Listopada
+3 Maja
+Adama Mickiewicza
+Akademicka
+Aleksandra Fredry
+Andrzeja Struga
+Andyjska
+Anhellego
+Anieli Krzywoń
+Armii Krajowej
+Artura Grottgera
+Azotowa
+Babiego Lata
+Babiogórska
+Bagienna
+Bajeczna
+Bajkowa
+Bakaliowa
+Balladyny
+Balonowa
+Bankowa
+Barbakan
+Bartnicza
+Bartosza Głowackiego
+Barwna
+Basenowa
+Batalionów Chłopskich
+Bałkańska
+Bałtycka
+Baśniowa
+Beskidzka
+Białoskórnicza
+Bielska
+Bohaterów Monte Cassino
+Bolesława Chrobrego
+Bolesława Limanowskiego
+Bolesława Prusa
+Bracka
+Browarna
+Brzeska
+Bytomska
+Chemiczna
+Chełmińska
+Chlebowa
+Chmielna
+Chmurna
+Chobolańska
+Chocimska
+Chojnicka
+Chorwacka
+Chorzowska
+Chłodna
+Chłopska
+Ciasna
+Deszczowa
+Dobra
+Dobrej Nadziei
+Dobropole
+Dobrzyńska
+Dworcowa
+Dębogórska
+Dębowa
+Długa
+Emila Zegadłowicza
+Emilii Gierczak
+Emilii Plater
+Emilii Sczanieckiej
+Energetyków
+Eugeniusza Romera
+Europejska
+Fabryczna
+Farna
+Feniksa
+Figowa
+Filaretów
+Floriańska
+Franciszkańska
+Francuska
+Fryderyka Chopina
+Gabriela Narutowicza
+Garbarska
+Gdańska
+gen. Władysława Andersa
+Gipsowa
+Giżycka
+Glazurowa
+Gliniana
+Glinkowa
+Gliwicka
+Gnieźnieńska
+Gołębia
+Graniczna
+Grodzka
+Grunwaldzka
+Górnośląska
+Gęsia
+Głogowska
+Głowicka
+Głucha
+Głęboka
+Hallera
+Henryka Sienkiewicza
+Hetmańska
+Himalajska
+Hipolita Cegielskiego
+Hodowlana
+Holenderska
+Honorowych Krwiodawców
+Horeszków
+Hołdu Pruskiego
+Hoża
+Hrubieszowska
+Ignacego Paderewskiego
+Jacka Malczewskiego
+Jacka Soplicy
+Jagiellońska
+Jagny
+Jagodowa
+Jakuba Bojki
+Jana Henryka Dąbrowskiego
+Jana III Sobieskiego
+Jana Karola Chodkiewicza
+Jana Kasprowicza
+Jana Kazimierza
+Jana Kilińskiego
+Jana Pawła II
+Jana z Kolna
+Janusza Korczaka
+Jezuicka
+Juliana Tuwima
+Juliusza Słowackiego
+Józefa Bema
+Józefa Piłsudskiego
+Józefa Poniatowskiego
+Kaczeńców
+Kadetów
+Kadmowa
+Kalinowa
+Kaliska
+Kameliowa
+Kameralna
+Kamienna
+Kamieńska
+Karmelicka
+Karola Olszewskiego
+Karola Świerczewskiego
+Kartuska
+Kasjopei
+Kaskadowa
+Kasztanowa
+Kaszubska
+Katedralna
+Katowicka
+Kazimierska
+Kazimierza Pułaskiego
+Kijowska
+Kmicica
+Kmieca
+Kniewska
+Kobaltowa
+Kokosowa
+Koksowa
+Kolarska
+Kolejowa
+Kolibra
+Kolonistów
+Krakowska
+Krakowskie Przedmieście
+Krucza
+Krupnicza
+Królewska
+Królowej Jadwigi
+ks. Jerzego Popiełuszki
+Kłosowa
+Kłuszyńska
+Lechicka
+Legionów
+Lipowa
+Lubelska
+Lwowska
+Łódzka
+Łąkowa
+Mariacka
+Migdałowa
+Mikołaja Kopernika
+Mikołaja Reja
+Mikołowska
+Milczańska
+Miodowa
+Mirabelki
+Mirtowa
+Misia Wojtka
+Miła
+Miłosławska
+Mokradłowa
+Monte Cassino
+Monterska
+Morawska
+Morelowa
+Morenowa
+Morska
+Morwowa
+Mostowa
+Mołdawska
+Młyńska
+Niepodległości
+Niestachowska
+Niezapominajki
+Niklowa
+Niny Rydzewskiej
+Norberta Barlickiego
+Norweska
+Notecka
+Nowowiejska
+Obornicka
+Obozowa
+Ogrodowa
+Okopowa
+Oliwkowa
+Olkuska
+Olsztyńska
+Olszynki Grochowskiej
+Opałowa
+Opolska
+Opłotki
+Oraczy
+Orawska
+Ołowiana
+Oświęcimska
+Partyzantów
+Perlista
+Perseusza
+Perłowa
+Piaseczna
+Piaskowa
+Piekarska
+Piotra Skargi
+Piwna
+Piękna
+Pocztowa
+Pomorska
+Poznańska
+Przyszłości
+Przytorze
+Przytulna
+Pszczelna
+Pszenna
+Pucka
+Pustułki
+Puszczykowa
+Puławska
+Północna
+Racławicka
+Rtęciowa
+Rubież
+Rubinowa
+Ruciana
+Ruda
+Rudzika
+Rugiańska
+Rumiankowa
+Rumuńska
+Ruska
+Róży Wiatrów
+Senatorska
+Siemianowicka
+Smutna
+Sobótki
+Sokolników
+Sokoła
+Solidarności
+Solna
+Sopocka
+Sosnowa
+Sowia
+Sołtysia
+Sośnicka
+Stanisława Małachowskiego
+Stanisława Staszica
+Starowiejska
+Stefana Starzyńskiego
+Stefana Wyszyńskiego
+Stefana Żeromskiego
+Stoisława
+Stokrotki
+Stolarska
+Storczykowa
+Stołczyńska
+Stroma
+Strumykowa
+Strusia
+Strzelecka
+Szczecińska
+Szeroka
+Szewska
+Szpitalna
+Sójki
+Śląska
+św. Ambrożego
+św. Anny
+św. Barbary
+św. Ducha
+św. Floriana
+św. Jakuba
+św. Jakuba Apostoła
+św. Jerzego
+św. Józefa
+św. Katarzyny
+św. Krzysztofa
+św. Krzyża
+św. Maksymiliana Kolbego
+św. Mikołaja
+św. Piotra
+św. Rozalii
+św. Stanisława
+św. Wojciecha
+Świętojańska
+Świętokrzyska
+Tadeusza Kościuszki
+Targowa
+Toruńska
+Towarowa
+Tropikalna
+Truskawkowa
+Trygława
+Trzcinowa
+Tucholska
+Tulipanowa
+Turkusowa
+Turystyczna
+Uniwersytecka
+Waleriana Pawłowskiego
+Waleriana Łukasińskiego
+Warszawska
+Wawelska
+Wałowa
+Wiejska
+Wielokwiatowa
+Wieluńska
+Wierzbowa
+Wiewiórcza
+Wikingów
+Wiklinowa
+Wilcza
+Wincentego Janasa
+Wincentego Witosa
+Wita Stwosza
+Wojska Polskiego
+Wolności
+Wrocławska
+Władysława Reymonta
+Władysława Sikorskiego
+Zachodnia
+Zagonowa
+Zagrzebska
+Zagłoby
+Zajęcza
+Zakopiańska
+Zakładowa
+Zamiejska
+Zamieć
+Zamknięta
+Zamkowa
+Zamojska
+Zapadła
+Załogowa
+Zbożowa
+Zbyszka z Bogdańca
+Zbójnicka
+Zdrojowa
+Zdrowa
+Zenona Klemensiewicza
+Zgierska
+Zgodna
+Zgody
+Zgorzelecka
+Zwierzyniecka
+Zwycięstwa
+Złota
+Żeglarska
+Żubrów
+Żurawia
+Żurawinowa
+Żwirki i Wigury
+Żwirowa
+Żytnia
+Żywiczna
+Żywiecka
+Żyzna

--- a/lib/ffaker/data/address_pl/voivodeship
+++ b/lib/ffaker/data/address_pl/voivodeship
@@ -1,0 +1,16 @@
+dolnośląskie
+kujawsko-pomorskie
+lubelskie
+lubuskie
+łódzkie
+małopolskie
+mazowieckie
+opolskie
+podkarpackie
+podlaskie
+pomorskie
+śląskie
+świętokrzyskie
+warmińsko-mazurskie
+wielkopolskie
+zachodniopomorskie

--- a/lib/ffaker/data/address_pl/voivodeship_abbr
+++ b/lib/ffaker/data/address_pl/voivodeship_abbr
@@ -1,0 +1,16 @@
+DS
+KP
+LU
+LB
+LD
+MA
+MZ
+OP
+PK
+PD
+PM
+SL
+SK
+WN
+WP
+ZP

--- a/lib/ffaker/data/address_pl/voivodeship_capital_city
+++ b/lib/ffaker/data/address_pl/voivodeship_capital_city
@@ -1,0 +1,18 @@
+Białystok
+Bydgoszcz
+Gdańsk
+Gorzów Wielkopolski
+Katowice
+Kielce
+Kraków
+Lublin
+Łódź
+Olsztyn
+Opole
+Poznań
+Rzeszów
+Szczecin
+Toruń
+Warszawa
+Wrocław
+Zielona Góra

--- a/test/test_address_pl.rb
+++ b/test/test_address_pl.rb
@@ -1,0 +1,81 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+
+require 'helper'
+
+class TestFakerAddressPL < Test::Unit::TestCase
+  include DeterministicHelper
+
+  assert_methods_are_deterministic(
+    FFaker::AddressPL,
+    :full_address, :street_address, :street_name, :street, :square, :voivodeship,
+    :voivodeship_abbr, :voivodeship_capital_city, :city, :building_number,
+    :secondary_number, :postal_code, :street_prefix, :square_prefix
+  )
+
+  def setup
+    @tester = FFaker::AddressPL
+  end
+
+  def test_full_address
+    assert_match(/[a-z]/, @tester.full_address)
+  end
+
+  def test_full_address_includes_country
+    assert_match(/POLOGNE/, @tester.full_address(true))
+  end
+
+  def street_address
+    assert_match(/[a-z]/, @tester.street_address)
+  end
+
+  def street_name
+    prefix, street = @tester.street_name.split
+    assert_include(@tester::STREET_PREFIXES + @tester::SQUARE_PREFIXES, prefix)
+    assert_include(@tester::STREET + @tester::SQUARE, street)
+  end
+
+  def street
+    assert_include(@tester::STREET, @tester.street)
+  end
+
+  def square
+    assert_include(@tester::SQUARE, @tester.square)
+  end
+
+  def voivodeship
+    assert_include(@tester::VOIVODESHIP, @tester.voivodeship)
+  end
+
+  def voivodeship_abbr
+    assert_include(@tester::VOIVODESHIP_ABBR, @tester.voivodeship_abbr)
+  end
+
+  def voivodeship_capital_city
+    assert_include(@tester::VOIVODESHIP_CAPITAL_CITY, @tester.voivodeship_capital_city)
+  end
+
+  def city
+    assert_include(@tester::CITY, @tester.city)
+  end
+
+  def building
+    assert_match(/\d{1,3}/, @tester.building)
+  end
+
+  def secondary_number
+    assert_match(/\d{1,3}/, @tester.secondary_number.split.last)
+  end
+
+  def postal_code
+    assert_match(/\d{2}-\d{3}/, @tester.postal_code)
+  end
+
+  def street_prefix
+    assert_include(@tester::STREET_PREFIXES, @tester.square_prefix)
+  end
+
+  def square_prefix
+    assert_include(@tester::SQUARE_PREFIXES, @tester.square_prefix)
+  end
+end


### PR DESCRIPTION
Added a `FFaker::AddressPL` module for generating Polish addresses. Voivodeships included.
Available methods:
- `full_address(include_country, include_secondary)`
- `street_address(include_secondary)`
- `street_name`
- `street`
- `square`
- `voivodeship`
- `voivodeship_abbr`
- `voivodeship_capital_city`
- `city`
- `building_number # :nodoc:`
- `secondary_number # :nodoc:`
- `postal_code`
- `street_prefix`
- `square_prefix`
