### PR TITLE
Incorrect HomeWorkOperatorsPrefix AU - 05 

### DIFF
--- a/lib/ffaker/phone_number_au.rb
+++ b/lib/ffaker/phone_number_au.rb
@@ -8,10 +8,10 @@ module FFaker
     extend self
 
     # Mobile prefixes
-    MobileOperatorsPrefix = %w(04).freeze
+    MobileOperatorsPrefix = %w(04 05).freeze
 
     # Home or Work Operator prefixes
-    HomeWorkOperatorsPrefix = %w(02 03 05 07 08).freeze
+    HomeWorkOperatorsPrefix = %w(02 03 07 08).freeze
 
     OperatorsPrefix = MobileOperatorsPrefix + HomeWorkOperatorsPrefix
 

--- a/test/test_phone_number_au.rb
+++ b/test/test_phone_number_au.rb
@@ -32,7 +32,9 @@ class TestPhoneNumberAU < Test::Unit::TestCase
   end
 
   def test_mobile_phone_number
-    assert_match(/04\d{2} \d{3} \d{3}/, FFaker::PhoneNumberAU.mobile_phone_number)
+    3.times do 
+      assert_match(/(04|05)\d{2} \d{3} \d{3}/, FFaker::PhoneNumberAU.mobile_phone_number)
+    end
   end
 
   def test_home_work_phone_number
@@ -41,7 +43,7 @@ class TestPhoneNumberAU < Test::Unit::TestCase
 
   def test_phone_number
     10.times do
-      assert_match(/(04\d{1,2} \d{3} \d{3}|\(\d{2}\) \d{4} \d{4})/, FFaker::PhoneNumberAU.phone_number)
+      assert_match(/((04|05)\d{1,2} \d{3} \d{3}|\(\d{2}\) \d{4} \d{4})/, FFaker::PhoneNumberAU.phone_number)
     end
   end
 


### PR DESCRIPTION
05 Prefix is for Mobile Phones as per wiki -
 https://en.wikipedia.org/wiki/Telephone_numbers_in_Australia#Mobile_phone_numbers_.2804.2C_05.29

Having it create for home work phone numbers is throwing a validation error using `GlobalPhone.parse(number, :au).valid?` as per https://github.com/googlei18n/libphonenumber/edit/master/resources/PhoneNumberMetadata.xml