### PR TITLE
Some lines of data/address_ja/city ends with '区'

### DIFF
--- a/test/test_address_ja.rb
+++ b/test/test_address_ja.rb
@@ -37,7 +37,7 @@ class TestAddressJA < Test::Unit::TestCase
   end
 
   def test_designated_city
-    assert_match(japanese_regex('市'), FFaker::AddressJA.city)
+    assert_match(japanese_regex('[市区]'), FFaker::AddressJA.city)
   end
 
   def test_city


### PR DESCRIPTION
At https://github.com/ffaker/ffaker/pull/314, @kojino said,

> The CI tests are still failing, but this is due to test_name_ar.rb and not Address::JA files.

No.

The test `test_designated_city` fails stochastically. This Pull Request fixes it.

You can check the stochastically failure with:

```bash
while true; do ruby -Ilib:test test/test_address_ja.rb -n test_designated_city; [ $? -ne 0 ] && break; done;
```

This one-liner shell script runs `test_designated_city` infinitely, and stops when the test fails. It stops at some point in time without this Pull Request. It runs infinitely with this Pull Request.

