### PR TITLE
Fix travis on 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 cache: bundler
 sudo: false
-before_install:
- - gem install bundler
- - bundle --version
+before_install: gem update bundler
 rvm:
  - 1.9
  - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 cache: bundler
 sudo: false
+before_install:
+ - gem install bundler
+ - bundle --version
 rvm:
  - 1.9
  - 2.0.0


### PR DESCRIPTION
[A RubyGems commit](https://github.com/rubygems/rubygems/commit/620910aa75c7446e8f8d5af1df5f981e4da86197) breaks cached gems on Bundler and [Bundler fixes it](https://github.com/bundler/bundler/commit/f4481a7e3dbaf7f563e32afbe2cbbb84e3091f16). The latest version of Bundler runs correctly on Travis CI so I add `gem update bundler` to `before_install` on `.travis.yml`.