### PR TITLE
Fix test_name_ar.rb

### DIFF
--- a/test/test_name_ar.rb
+++ b/test/test_name_ar.rb
@@ -29,12 +29,12 @@ class TestFakerNameAR < Test::Unit::TestCase
   end
 
   def test_name_male
-    expected_list = @tester::FIRST_NAMES_MALE.product(@tester::LAST_NAMES).map { |set| set.join(' ') }
-    assert_include(expected_list, @tester.name_male)
+    expected = @tester::FIRST_NAMES_MALE.product(@tester::LAST_NAMES).map { |set| set.join(' ') }
+    assert_include(expected, @tester.name_male)
   end
 
   def test_name_female
-    expected_list = @tester::FIRST_NAMES_FEMALE.product(@tester::LAST_NAMES).map { |set| set.join(' ') }
-    assert_include(expected_list, @tester.name_female)
+    expected = @tester::FIRST_NAMES_FEMALE.product(@tester::LAST_NAMES).map { |set| set.join(' ') }
+    assert_include(expected, @tester.name_female)
   end
 end

--- a/test/test_name_ar.rb
+++ b/test/test_name_ar.rb
@@ -29,14 +29,12 @@ class TestFakerNameAR < Test::Unit::TestCase
   end
 
   def test_name_male
-    first_name, last_name = @tester.name_male.split(/\s+/, 2)
-    assert_include(@tester::FIRST_NAMES_MALE, first_name)
-    assert_include(@tester::LAST_NAMES, last_name)
+    expected_list = @tester::FIRST_NAMES_MALE.product(@tester::LAST_NAMES).map { |set| set.join(' ') }
+    assert_include(expected_list, @tester.name_male)
   end
 
   def test_name_female
-    first_name, last_name = @tester.name_female.split(/\s+/, 2)
-    assert_include(@tester::FIRST_NAMES_FEMALE, first_name)
-    assert_include(@tester::LAST_NAMES, last_name)
+    expected_list = @tester::FIRST_NAMES_FEMALE.product(@tester::LAST_NAMES).map { |set| set.join(' ') }
+    assert_include(expected_list, @tester.name_female)
   end
 end


### PR DESCRIPTION
The `test_name_ar.rb` is added at https://github.com/ffaker/ffaker/pull/312.

Some names of `FFaker::NameAR::FIRST_NAMES_MALE` and `FFaker::NameAR::LAST_NAMES` have space, but some tests on `test_name_ar.rb` try to separate full name by space, and there are spaces outside between first name and last name. So the tests fail stochastically.

This Pull Request fixes it.