### PR TITLE
Drop support for ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 sudo: false
 before_install: gem update bundler
 rvm:
- - 1.9
  - 2.0.0
  - 2.1
  - 2.2

--- a/ffaker.gemspec
+++ b/ffaker.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version           = '2.7.0'
   s.date              = '2017-09-19'
   s.rubyforge_project = 'ffaker'
-  s.required_ruby_version = '>= 1.9'
+  s.required_ruby_version = '>= 2.0'
 
   s.license = 'MIT'
 


### PR DESCRIPTION
Ruby 1.9 was broken by 3b279e031af01238bf30a46489a6fc418d90f21a (use of `%i[foo bar]` syntax) so CI is currently failing.

Ruby 1.9 reached EOL February 23, 2015, so I don't think it is worth supporting.