### PR TITLE
force using UTF-8

### DIFF
--- a/lib/ffaker/utils/module_utils.rb
+++ b/lib/ffaker/utils/module_utils.rb
@@ -16,7 +16,7 @@ module FFaker
       else
         mod_name = ancestors.first.to_s.split('::').last
         data_path = "#{FFaker::BASE_LIB_PATH}/ffaker/data/#{underscore(mod_name)}/#{underscore(const_name.to_s)}"
-        data = k File.read(data_path).split("\n")
+        data = k File.read(data_path, mode: 'r:UTF-8').split("\n")
         const_set const_name, data
         data
       end


### PR DESCRIPTION
fixes `Uncaught exception: invalid byte sequence in US-ASCII` when using RubyMine's debugger