### PR TITLE
Updated password generation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1152,7 +1152,7 @@
 | `http_url` | http://bruen.ca, http://hodkiewicznolan.name, http://bailey.us |
 | `ip_v4_address` | 207.181.113.110, 79.217.87.253, 105.199.37.154 |
 | `mac` | 2a:a6:12:81:fd:b5, bb:68:c2:6b:ba:87, b5:7c:7d:0c:4d:6a |
-| `password` | iiiiiiiiiii, nnnnnnnnnnnnnn, uuuuuuuuuuuuu |
+| `password` | dHrAEqmF_w3Qdiw, Gczh921Vvs, 1dF9A6YS |
 | `safe_email` | towanda@example.net, lashanda.mohr@example.com, dori_stamm@example.net |
 | `slug` | numquam.unde, corrupti-in, qui_harum |
 | `uri`(...) |  |
@@ -1174,7 +1174,7 @@
 | `join_to_user_name`(...) |  |
 | `login_user_name` | florencio, scot, gerardbreitenberg |
 | `mac` | b1:d7:39:ce:c6:a9, 88:9b:2b:9c:c6:1d, 27:05:b6:83:9a:5f |
-| `password` | zzzzzzzzzzzzzzz, ooooooooooooooo, eeeeeeee |
+| `password` | 5SpbF4WkKi56s, I_IVVowRKR1, 9Iha_R24Yc6 |
 | `safe_email` | mitchell@example.net, nolan_brown@example.com, dorla@example.org |
 | `slug` | consequatur.reprehenderit, neque.vero, vel-sint |
 | `uri`(...) |  |

--- a/lib/ffaker/internet.rb
+++ b/lib/ffaker/internet.rb
@@ -81,7 +81,7 @@ module FFaker
     def password(min_length = 8, max_length = 16)
       length =
         min_length > max_length ? min_length : fetch_sample([*min_length..max_length])
-      String.from_regexp(/[a-z]{#{length}}/)
+      String.from_regexp(/\w{#{length}}/)
     end
 
     def mac(delimiter = ':')

--- a/test/test_internet.rb
+++ b/test/test_internet.rb
@@ -89,7 +89,7 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_password
-    assert_match(/\A[a-z]+\z/, @tester.password)
+    assert_match(/\A\w+\z/, @tester.password)
   end
 
   def test_password_min_length


### PR DESCRIPTION
Changed `regexp` in `FFaker::Internet::password`. Works with only numbers, letters and `_`
