### PR TITLE
Add orly book cover generator

### DIFF
--- a/lib/ffaker/book.rb
+++ b/lib/ffaker/book.rb
@@ -2,6 +2,8 @@
 
 module FFaker
   module Book
+    require 'cgi'
+
     extend ModuleUtils
     extend self
 
@@ -30,6 +32,15 @@ module FFaker
 
     def cover(slug = nil, size = '300x300', format = 'png', bgset = nil)
       FFaker::Avatar.image(slug, size, format, bgset)
+    end
+
+    def orly_cover(name = title, book_author = author, top_text = genre)
+      'https://orly-appstore.herokuapp.com/generate?'\
+        "title=#{CGI.escape(name)}&"\
+        "top_text=#{CGI.escape(top_text)}&"\
+        "author=#{CGI.escape(book_author)}&"\
+        "image_code=#{Random.rand(1..40)}&"\
+        "theme=#{Random.rand(1..16)}"
     end
 
     private

--- a/test/test_book.rb
+++ b/test/test_book.rb
@@ -38,4 +38,9 @@ class TestBook < Test::Unit::TestCase
     assert_match(%r{\Ahttps:\/\/robohash\.org\/.+\.png\?size=300x300\z},
                  @tester.cover)
   end
+
+  def test_orly_cover
+    assert_match(%r{\Ahttps:\/\/orly-appstore\.herokuapp\.com\/generate},
+                 @tester.orly_cover)
+  end
 end


### PR DESCRIPTION
I found this cool book covers generator: https://dev.to/rly

It's cool, but I see problems with it:
1. It's hosted on heroku (probably free)
2. Author probably should be notified about usage
3. It doesn't return url with extension

I'm ready to add more tests if this generator is useful in gem

<details>
<summary>Click to see sample image</summary>
<img src="https://user-images.githubusercontent.com/9060346/35525057-79f8e7e6-0534-11e8-8bef-16b20d8749a9.png"/>
</details>