### PR TITLE
Make FFaker::SSN.ssn generate only valid SSNs

### DIFF
--- a/lib/ffaker/ssn.rb
+++ b/lib/ffaker/ssn.rb
@@ -11,7 +11,7 @@ module FFaker
     # http://en.wikipedia.org/wiki/Social_Security_number
     #
     def ssn
-      first_group  = fetch_sample([rand(1..665), rand(667..899)])
+      first_group  = fetch_sample([*1..665, *667..899])
       second_group = rand(1..99)
       third_group  = rand(1..9999)
 

--- a/lib/ffaker/ssn.rb
+++ b/lib/ffaker/ssn.rb
@@ -11,7 +11,14 @@ module FFaker
     # http://en.wikipedia.org/wiki/Social_Security_number
     #
     def ssn
-      FFaker.numerify('###-##-####')
+      first_group  = [rand(1..665), rand(667..899)].sample
+      second_group = rand(1..99)
+      third_group  = rand(1..9999)
+
+      group_numbers = [first_group, second_group, third_group]
+      result = '%.3d-%.2d-%.4d' % group_numbers
+
+      result
     end
   end
 end

--- a/lib/ffaker/ssn.rb
+++ b/lib/ffaker/ssn.rb
@@ -11,7 +11,7 @@ module FFaker
     # http://en.wikipedia.org/wiki/Social_Security_number
     #
     def ssn
-      first_group  = [rand(1..665), rand(667..899)].sample
+      first_group  = fetch_sample([rand(1..665), rand(667..899)])
       second_group = rand(1..99)
       third_group  = rand(1..9999)
 

--- a/lib/ffaker/ssn.rb
+++ b/lib/ffaker/ssn.rb
@@ -16,7 +16,7 @@ module FFaker
       third_group  = rand(1..9999)
 
       group_numbers = [first_group, second_group, third_group]
-      result = '%.3d-%.2d-%.4d' % group_numbers
+      result = format('%.3d-%.2d-%.4d', *group_numbers)
 
       result
     end

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -16,13 +16,13 @@ class TestSSN < Test::Unit::TestCase
     assert_match(/\A[0-8]\d{2}-\d{2}-\d{4}\Z/, @actual_ssn)
   end
 
-  def test_ssn_second_group_positive
+  def test_ssn_second_group_non_zero
     _first, second_group, _third = ssn_to_number_groups(@actual_ssn)
 
     assert(second_group != 0)
   end
 
-  def test_ssn_third_group_positive
+  def test_ssn_third_group_non_zero
     *_other, third_group = ssn_to_number_groups(@actual_ssn)
 
     assert(third_group != 0)
@@ -33,8 +33,8 @@ class TestSSN < Test::Unit::TestCase
   def ssn_to_number_groups(ssn)
     groups = ssn.split('-')
 
-    numbers = groups.map { |g| strip_leading_zeros(g) }
-                    .map { |g| Integer(g) }
+    stripped_groups = groups.map { |g| strip_leading_zeros(g) }
+    numbers = stripped_groups.map { |g| Integer(g) }
 
     numbers
   end

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -16,30 +16,12 @@ class TestSSN < Test::Unit::TestCase
     assert_match(/\A[0-8]\d{2}-\d{2}-\d{4}\Z/, @actual_ssn)
   end
 
-  def test_ssn_second_group_non_zero
-    _first, second_group, _third = ssn_to_number_groups(@actual_ssn)
+  def test_ssn_groups_non_zero
+    first_group, second_group, third_group = @actual_ssn.split('-')
+    with_all_zeros = /\A0+\Z/
 
-    assert(second_group != 0)
-  end
-
-  def test_ssn_third_group_non_zero
-    *_other, third_group = ssn_to_number_groups(@actual_ssn)
-
-    assert(third_group != 0)
-  end
-
-  private
-
-  def ssn_to_number_groups(ssn)
-    groups = ssn.split('-')
-
-    stripped_groups = groups.map { |g| strip_leading_zeros(g) }
-    numbers = stripped_groups.map { |g| Integer(g) }
-
-    numbers
-  end
-
-  def strip_leading_zeros(string)
-    string.gsub(/\A0+(?!\Z)/, '')
+    assert_no_match(with_all_zeros, first_group)
+    assert_no_match(with_all_zeros, second_group)
+    assert_no_match(with_all_zeros, third_group)
   end
 end

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -19,13 +19,13 @@ class TestSSN < Test::Unit::TestCase
   def test_ssn_second_group_positive
     _first, second_group, _third = ssn_to_number_groups(@actual_ssn)
 
-    assert(second_group > 0)
+    assert(second_group != 0)
   end
 
   def test_ssn_third_group_positive
     *_other, third_group = ssn_to_number_groups(@actual_ssn)
 
-    assert(third_group > 0)
+    assert(third_group != 0)
   end
 
   private

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -7,35 +7,39 @@ class TestSSN < Test::Unit::TestCase
 
   assert_methods_are_deterministic(FFaker::SSN, :ssn)
 
+  def setup
+    @actual_ssn = FFaker::SSN.ssn
+  end
+
   def test_ssn_format
-    assert_match(/\A\d{3}-\d{2}-\d{4}\Z/, FFaker::SSN.ssn)
+    assert_match(/\A\d{3}-\d{2}-\d{4}\Z/, @actual_ssn)
   end
 
   def test_ssn_first_group_in_valid_range
-    ssn = FFaker::SSN.ssn
-    first_group, *_other_groups = ssn.split('-')
+    first_group, *_other = ssn_to_number_groups(@actual_ssn)
 
-    first_number = Integer(first_group)
-
-    assert first_number != 666
-    assert first_number  < 900
+    assert first_group != 666
+    assert first_group  < 900
   end
 
   def test_ssn_second_group_non_zero
-    ssn = FFaker::SSN.ssn
-    _first_group, second_group, _third_group = ssn.split('-')
+    _first, second_group, _third = ssn_to_number_groups(@actual_ssn)
 
-    second_number = Integer(second_group)
-
-    assert second_number.positive?
+    assert second_group.positive?
   end
 
   def test_ssn_third_group_non_zero
-    ssn = FFaker::SSN.ssn
-    _first_group, _second_group, third_group = ssn.split('-')
+    *_other, third_group = ssn_to_number_groups(@actual_ssn)
 
-    third_number = Integer(third_group)
+    assert third_group.positive?
+  end
 
-    assert third_number.positive?
+  private
+
+  def ssn_to_number_groups(ssn)
+    groups = ssn.split('-')
+    numbers = groups.map { |g| Integer(g) }
+
+    numbers
   end
 end

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -12,10 +12,6 @@ class TestSSN < Test::Unit::TestCase
   end
 
   def test_ssn_format
-    assert_match(/\A\d{3}-\d{2}-\d{4}\Z/, @actual_ssn)
-  end
-
-  def test_ssn_first_group_in_valid_range
     assert_no_match(/\A666/, @actual_ssn)
     assert_match(/\A[0-8]\d{2}-\d{2}-\d{4}\Z/, @actual_ssn)
   end

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -7,7 +7,35 @@ class TestSSN < Test::Unit::TestCase
 
   assert_methods_are_deterministic(FFaker::SSN, :ssn)
 
-  def test_ssn
+  def test_ssn_format
     assert_match(/\d{3}-\d{2}-\d{3}/, FFaker::SSN.ssn)
+  end
+
+  def test_ssn_first_group_in_valid_range
+    ssn = FFaker::SSN.ssn
+    first_group, *_other_groups = ssn.split('-')
+
+    first_number = Integer(first_group)
+
+    assert first_number != 666
+    assert first_number  < 900
+  end
+
+  def test_ssn_second_group_non_zero
+    ssn = FFaker::SSN.ssn
+    _first_group, second_group, _third_group = ssn.split('-')
+
+    second_number = Integer(second_group)
+
+    assert second_number.positive?
+  end
+
+  def test_ssn_third_group_non_zero
+    ssn = FFaker::SSN.ssn
+    _first_group, _second_group, third_group = ssn.split('-')
+
+    third_number = Integer(third_group)
+
+    assert third_number.positive?
   end
 end

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -38,8 +38,15 @@ class TestSSN < Test::Unit::TestCase
 
   def ssn_to_number_groups(ssn)
     groups = ssn.split('-')
-    numbers = groups.map { |g| Integer(g) }
+
+    numbers = groups
+      .map { |g| strip_leading_zeros(g) }
+      .map { |g| Integer(g) }
 
     numbers
+  end
+
+  def strip_leading_zeros(s)
+    s.gsub(/\A0+(?!\Z)/, '')
   end
 end

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -8,7 +8,7 @@ class TestSSN < Test::Unit::TestCase
   assert_methods_are_deterministic(FFaker::SSN, :ssn)
 
   def test_ssn_format
-    assert_match(/\d{3}-\d{2}-\d{3}/, FFaker::SSN.ssn)
+    assert_match(/\A\d{3}-\d{2}-\d{4}\Z/, FFaker::SSN.ssn)
   end
 
   def test_ssn_first_group_in_valid_range

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -18,20 +18,20 @@ class TestSSN < Test::Unit::TestCase
   def test_ssn_first_group_in_valid_range
     first_group, *_other = ssn_to_number_groups(@actual_ssn)
 
-    assert first_group != 666
-    assert first_group  < 900
+    assert(first_group != 666)
+    assert(first_group  < 900)
   end
 
   def test_ssn_second_group_non_zero
     _first, second_group, _third = ssn_to_number_groups(@actual_ssn)
 
-    assert second_group.positive?
+    assert(second_group.positive?)
   end
 
   def test_ssn_third_group_non_zero
     *_other, third_group = ssn_to_number_groups(@actual_ssn)
 
-    assert third_group.positive?
+    assert(third_group.positive?)
   end
 
   private

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -22,16 +22,16 @@ class TestSSN < Test::Unit::TestCase
     assert(first_group < 900)
   end
 
-  def test_ssn_second_group_non_zero
+  def test_ssn_second_group_positive
     _first, second_group, _third = ssn_to_number_groups(@actual_ssn)
 
-    assert(second_group.positive?)
+    assert(second_group > 0)
   end
 
-  def test_ssn_third_group_non_zero
+  def test_ssn_third_group_positive
     *_other, third_group = ssn_to_number_groups(@actual_ssn)
 
-    assert(third_group.positive?)
+    assert(third_group > 0)
   end
 
   private

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -19,7 +19,7 @@ class TestSSN < Test::Unit::TestCase
     first_group, *_other = ssn_to_number_groups(@actual_ssn)
 
     assert(first_group != 666)
-    assert(first_group  < 900)
+    assert(first_group < 900)
   end
 
   def test_ssn_second_group_non_zero
@@ -39,14 +39,13 @@ class TestSSN < Test::Unit::TestCase
   def ssn_to_number_groups(ssn)
     groups = ssn.split('-')
 
-    numbers = groups
-      .map { |g| strip_leading_zeros(g) }
-      .map { |g| Integer(g) }
+    numbers = groups.map { |g| strip_leading_zeros(g) }
+                    .map { |g| Integer(g) }
 
     numbers
   end
 
-  def strip_leading_zeros(s)
-    s.gsub(/\A0+(?!\Z)/, '')
+  def strip_leading_zeros(string)
+    string.gsub(/\A0+(?!\Z)/, '')
   end
 end

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -16,10 +16,8 @@ class TestSSN < Test::Unit::TestCase
   end
 
   def test_ssn_first_group_in_valid_range
-    first_group, *_other = ssn_to_number_groups(@actual_ssn)
-
-    assert(first_group != 666)
-    assert(first_group < 900)
+    assert_no_match(/\A666/, @actual_ssn)
+    assert_match(/\A[0-8]\d{2}-\d{2}-\d{4}\Z/, @actual_ssn)
   end
 
   def test_ssn_second_group_positive


### PR DESCRIPTION
https://github.com/ffaker/ffaker/issues/348

From [wikipedia](https://en.wikipedia.org/wiki/Social_Security_number#Valid_SSNs):

```
Some special numbers are never allocated:

Numbers with all zeros in any digit group (000-##-####, ###-00-####, ###-##-0000).
Numbers with 666 or 900-999 (Individual Taxpayer Identification Number) in the first digit group.
```

Tests included.

Please let me know if there's something wrong and I will gladly address any changes requests.

Have a nice day!
