### PR TITLE
Add non-binary terms to the Gender module

### DIFF
--- a/lib/ffaker/gender.rb
+++ b/lib/ffaker/gender.rb
@@ -5,7 +5,7 @@ module FFaker
     extend ModuleUtils
     extend self
 
-    GENDERS = %w[male female].freeze
+    GENDERS = %w[male female non-binary agender androgyne bi-gender pan-gender].freeze
 
     def random
       fetch_sample(GENDERS)

--- a/test/test_gender.rb
+++ b/test/test_gender.rb
@@ -12,7 +12,7 @@ class TestFakerGender < Test::Unit::TestCase
   end
 
   def test_random
-    gender_regex = /\A(male|female)\z/
+    gender_regex = /\A(male|female|non-binary|agender|androgyne|bi-gender|pan-gender)\z/
     assert_match(gender_regex, @tester.random)
   end
 end


### PR DESCRIPTION
We can better serve our end-users if we use a more inclusive set of terms.

Here’s some documentation from Wikipedia: https://en.wikipedia.org/wiki/Genderqueer

Genderqueer, also known as non-binary, is a catch-all category for gender identities that are not exclusively masculine or feminine‍—‌identities which are outside the gender binary and cisnormativity.[1] Genderqueer people may express a combination of masculinity and femininity, or neither, in their gender expression.

Genderqueer people may identify as either having an overlap of, or indefinite lines between, gender identity;[2] having two or more genders (being bigender, trigender, or pangender); having no gender (being agender, nongendered, genderless, genderfree or neutrois); moving between genders or having a fluctuating gender identity (genderfluid);[3] or being third gender or other-gendered, a category which includes those who do not place a name to their gender.[4]

Gender identity is separate from sexual or romantic orientation,[5] and genderqueer people have a variety of sexual orientations, just as transgender and cisgender people do.[6]