### PR TITLE
Add optional length range for internet usernames

### DIFF
--- a/lib/ffaker/internet.rb
+++ b/lib/ffaker/internet.rb
@@ -45,7 +45,8 @@ module FFaker
           return adjust_username_length(username, min_length, max_length) if range_applied
           username
         when 1
-          username = [Name.first_name, Name.last_name].map { |n| sanitize(n) }.join(fetch_sample(%w[. _]))
+          username =
+            [Name.first_name, Name.last_name].map { |n| sanitize(n) }.join(fetch_sample(%w[. _]))
           return adjust_username_length(username, min_length, max_length) if range_applied
           username
         end

--- a/lib/ffaker/internet_se.rb
+++ b/lib/ffaker/internet_se.rb
@@ -31,14 +31,21 @@ module FFaker
     end
 
     # Used to fake login names were dot is not allowed
-    def login_user_name
-      user_name.tr('.', '')
+    def login_user_name(min_length: nil, max_length: nil)
+      user_name(min_length: min_length, max_length: max_length).tr('.', '')
     end
 
     # Mostly used for email creation
-    def user_name(name = nil)
-      return user_name_from_name(name) if name
-      user_name_random
+    def user_name(name = nil, min_length: nil, max_length: nil)
+      range_applied = min_length && max_length
+
+      if range_applied
+        return adjust_username_length(user_name_from_name(name), min_length, max_length) if name
+        adjust_username_length(user_name_random, min_length, max_length)
+      else
+        return user_name_from_name(name) if name
+        user_name_random
+      end
     end
 
     def user_name_random

--- a/test/test_internet.rb
+++ b/test/test_internet.rb
@@ -38,6 +38,14 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_user_name
     assert @tester.user_name.match(/[a-z]+((_|\.)[a-z]+)?/)
+
+    username = @tester.user_name(min_length: 3, max_length: 15)
+    assert username.length >= 3 && username.length <= 15
+    assert username.match(/[a-z]+((_|\.)[a-z]+)?/)
+
+    username = @tester.user_name(min_length: 8, max_length: 10)
+    assert username.length >= 8 && username.length <= 10
+    assert username.match(/[a-z]+((_|\.)[a-z]+)?/)
   end
 
   def test_user_name_with_arg

--- a/test/test_internet_se.rb
+++ b/test/test_internet_se.rb
@@ -35,10 +35,26 @@ class TestFakerInternetSE < Test::Unit::TestCase
 
   def test_login_user_name
     assert @tester.login_user_name.match(/[a-z]+((_|)[a-z]+)?/)
+
+    username = @tester.login_user_name(min_length: 5, max_length: 6)
+    assert username.length >= 5 && username.length <= 6
+    assert username.match(/[a-z]+((_|)[a-z]+)?/)
+
+    username = @tester.login_user_name(min_length: 15, max_length: 20)
+    assert username.length >= 15 && username.length <= 20
+    assert username.match(/[a-z]+((_|)[a-z]+)?/)
   end
 
   def test_user_name
     assert @tester.user_name.match(/[a-z]+((_|\.)[a-z]+)?/)
+
+    username = @tester.user_name(min_length: 3, max_length: 4)
+    assert username.length >= 3 && username.length <= 4
+    assert username.match(/[a-z]+((_|\.)[a-z]+)?/)
+
+    username = @tester.user_name(min_length: 1, max_length: 2)
+    assert username.length >= 1 && username.length <= 2
+    assert username.match(/[a-z]+((_|\.)[a-z]+)?/)
   end
 
   def test_user_name_with_arg


### PR DESCRIPTION
Optional Min Max length range username method arguments, for internet and internetSe user_name methods.

This can be done now with this PR

```ruby
FFaker::InternetSE.login_user_name(min_length: 8, max_length: 15)
```

It will either trim or add random alphabet characters to be within the given range

Also added the functionality to expand any internet username generation with range