### PR TITLE
Changing mobile_phone_prefix to reflect current prefixes

### DIFF
--- a/lib/ffaker/phone_number_br.rb
+++ b/lib/ffaker/phone_number_br.rb
@@ -8,6 +8,7 @@ module FFaker
   # - http://www.teleco.com.br/num_cel.asp
   # - http://ddd.online24hs.com.br/
   # - https://tecnoblog.net/24850/prefixo-10-para-grande-sao-paulo-deve-comecar-a-funcionar-em-outubro/
+  # - http://agenciabrasil.ebc.com.br/geral/noticia/2016-10/numeros-de-celulares-de-todo-o-pais-terao-nove-digitos-partir-do-dia-6
   #
   module PhoneNumberBR
     extend ModuleUtils
@@ -20,7 +21,7 @@ module FFaker
     ].flat_map { |x| Array(x) }.map(&:to_s).freeze
 
     HOME_WORK_PHONE_PREFIX = %w[2 3 4 5].freeze
-    MOBILE_PHONE_PREFIX    = %w[6 7 8 9 96 97 98 99].freeze
+    MOBILE_PHONE_PREFIX    = %w[96 97 98 99].freeze
     PHONE_NUMBER           = %w[####### ###-####].freeze
 
     # generate a random phone number

--- a/test/test_phone_number_br.rb
+++ b/test/test_phone_number_br.rb
@@ -38,7 +38,7 @@ class TestPhoneNumberBR < Test::Unit::TestCase
   end
 
   def test_mobile_phone_number
-    assert_match(/\A[1-9]\d\s?([6-9]|9[6-9])\d{3}-?\d{4}\z/,
+    assert_match(/\A[1-9]\d\s?9[6-9]\d{3}-?\d{4}\z/,
                  @tester.mobile_phone_number)
   end
 
@@ -50,7 +50,7 @@ class TestPhoneNumberBR < Test::Unit::TestCase
   end
 
   def test_international_mobile_phone_number
-    assert_match(/\A\+55\s?[1-9]\d\s?([6-9]|9[6-9])\d{3}-?\d{4}\z/,
+    assert_match(/\A\+55\s?[1-9]\d\s?9[6-9]\d{3}-?\d{4}\z/,
                  @tester.international_mobile_phone_number)
   end
 


### PR DESCRIPTION
For a while now brazillian mobile phone numbers have had the fixed 9 instead of only in some special cases, this change reflects that.