### PR TITLE
Drop support of under 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+AllCops:
+  TargetRubyVersion: 2.4
 Style/FrozenStringLiteralComment:
   Enabled: true
 Style/StringLiterals:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ before_install:
   - gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
   - gem update bundler --conservative
 rvm:
- - 2.0
- - 2.1
- - 2.2
- - 2.3
  - 2.4
  - 2.5
+ - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 cache: bundler
 sudo: false
-before_install:
-  - gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
-  - gem update bundler --conservative
 rvm:
  - 2.4
  - 2.5

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## development
+  - *BREAKING CHANGE*: Drop support of under 2.3  [@marocchino]
 
 ## 2.11.0
   - Add HealthcareRU [@gruz0]

--- a/ffaker.gemspec
+++ b/ffaker.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version           = '2.11.0'
   s.date              = '2018-01-04'
   s.rubyforge_project = 'ffaker'
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.4'
 
   s.license = 'MIT'
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/