### PR TITLE
Add pronouns to FFaker::Name

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1463,6 +1463,7 @@
 | `other_prefix` | Ms., Ms., Ms. |
 | `prefix` | Mr., Miss., Mrs. |
 | `suffix` | III, II, DVM |
+| `pronouns` | He/Him, She/Her, They/Their, Zie/Zim, Xe/Xem, Xe/Xer |
 
 ## FFaker::NameAR
 

--- a/lib/ffaker/data/name/pronouns
+++ b/lib/ffaker/data/name/pronouns
@@ -1,0 +1,6 @@
+He/Him
+She/Her
+They/Them
+Zie/Zim
+Xe/Xem
+Xe/Xer

--- a/lib/ffaker/name.rb
+++ b/lib/ffaker/name.rb
@@ -111,5 +111,9 @@ module FFaker
     def suffix
       fetch_sample(SUFFIXES)
     end
+
+    def pronouns
+      fetch_sample(PRONOUNS)
+    end
   end
 end

--- a/test/test_name.rb
+++ b/test/test_name.rb
@@ -9,7 +9,7 @@ class TestFakerName < Test::Unit::TestCase
     :name_with_suffix, :female_name_with_suffix, :male_name_with_suffix,
     :name_with_prefix_suffix, :female_name_with_prefix_suffix, :male_name_with_prefix_suffix,
     :first_name, :first_name_female, :first_name_male, :last_name,
-    :prefix, :female_prefix, :male_prefix, :other_prefix, :suffix
+    :prefix, :female_prefix, :male_prefix, :other_prefix, :suffix, :pronouns
   )
 
   def setup
@@ -128,5 +128,9 @@ class TestFakerName < Test::Unit::TestCase
 
   def test_suffix
     assert_match(/[A-Z][a-z]*\.?/, @tester.suffix)
+  end
+
+  def test_pronouns
+    assert_include(@tester::PRONOUNS, @tester.pronouns)
   end
 end


### PR DESCRIPTION
This PR adds a small set of gender-inclusive pronouns to FFaker::Name. 

This was useful to me in testing an app that (among many other things) tracks preferred pronouns for contacts and users, and I pass it along with the hope it will be useful to others.