### PR TITLE
Add Polish identification.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -70,6 +70,7 @@
  * [FFaker::IdentificationESCO](#ffakeridentificationesco)
  * [FFaker::IdentificationKr](#ffakeridentificationkr)
  * [FFaker::IdentificationMX](#ffakeridentificationmx)
+ * [FFaker::IdentificationPL](#ffakeridentificationpl)
  * [FFaker::Image](#ffakerimage)
  * [FFaker::Internet](#ffakerinternet)
  * [FFaker::InternetSE](#ffakerinternetse)
@@ -1202,6 +1203,14 @@
 | `rfc` | REAG870911CB2, ÑEDH820917F13, MHÑ780425ACI |
 | `rfc_persona_fisica` | BEHW7007246NE, XOQW7111161QZ, DUOY990416G12 |
 | `rfc_persona_moral` | DUJ1004129M7, HSA930723WU3, RÑI161008SJ8 |
+
+## FFaker::IdentificationPL
+
+| Method | Example |
+| ------ | ------- |
+| `pesel` | 82042691480, 05221154824, 53073028936 |
+| `identity_card` | AKH956298, CPI928237, VYB372774 |
+| `drivers_license` | 47704/10/7415, 20409/05/8025, 90741/34/4389 |
 
 ## FFaker::Image
 

--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -104,6 +104,7 @@ module FFaker
   autoload :IdentificationESCO, 'ffaker/identification_es_co'
   autoload :IdentificationKr, 'ffaker/identification_kr'
   autoload :IdentificationMX, 'ffaker/identification_mx'
+  autoload :IdentificationPL, 'ffaker/identification_pl'
   autoload :Image, 'ffaker/image'
   autoload :Internet, 'ffaker/internet'
   autoload :InternetSE, 'ffaker/internet_se'

--- a/lib/ffaker/identification_pl.rb
+++ b/lib/ffaker/identification_pl.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'date'
+
+module FFaker
+  module IdentificationPL
+    extend ModuleUtils
+    extend self
+
+    # Polish national identification number
+    # https://en.wikipedia.org/wiki/PESEL
+    def pesel
+      date = generate_valid_pesel_date
+      birthdate = pesel_birthdate(date)
+      serial_number = FFaker.numerify('####')
+      checksum = pesel_checksum(birthdate, serial_number)
+      "#{birthdate}#{serial_number}#{checksum}"
+    end
+
+    # Polish identity card number
+    # https://en.wikipedia.org/wiki/Polish_identity_card
+    def identity_card
+      letter_part = FFaker.letterify('???').upcase
+      number_part = FFaker.numerify('#####')
+      checksum = identity_card_checksum(letter_part, number_part)
+      "#{letter_part}#{checksum}#{number_part}"
+    end
+
+    alias id identity_card
+
+    # Polish driver's licence number
+    # https://en.wikipedia.org/wiki/Driving_licence_in_Poland
+    def drivers_license
+      FFaker.numerify('#####/##/####')
+    end
+
+    private
+
+    def generate_valid_pesel_date
+      from = Date.new(1800, 1, 1)
+      to = [Date.today, Date.new(2299, 12, 31)].min
+      fetch_sample([*from..to])
+    end
+
+    def pesel_birthdate(date)
+      century_differentiator = pesel_century_differentiator(date.year)
+
+      year = date.strftime('%y')
+      month = century_differentiator.zero? ? date.strftime('%m') : date.month + century_differentiator
+      day = date.strftime('%d')
+
+      "#{year}#{month}#{day}"
+    end
+
+    def pesel_century_differentiator(year)
+      case year
+      when 1800..1899 then 80
+      when 2000..2099 then 20
+      when 2100..2199 then 40
+      when 2200..2299 then 60
+      else 0
+      end
+    end
+
+    def pesel_checksum(date, serial_number)
+      pesel_digits = "#{date}#{serial_number}".split('').map(&:to_i)
+      a, b, c, d, e, f, g, h, i, j = pesel_digits
+      (a * 9 + b * 7 + c * 3 + d + e * 9 + f * 7 + g * 3 + h + i * 9 + j * 7) % 10
+    end
+
+    def identity_card_checksum(letter_part, number_part)
+      a, b, c = letter_part.codepoints.map { |codepoints| codepoints - 55 }
+      d, e, f, g, h = number_part.split('').map(&:to_i)
+      (a * 7 + b * 3 + c + 7 * d + 3 * e + f + 7 * g + 3 * h) % 10
+    end
+  end
+end

--- a/test/test_identification_pl.rb
+++ b/test/test_identification_pl.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+class TestFakerIdentificationPL < Test::Unit::TestCase
+  include DeterministicHelper
+
+  assert_methods_are_deterministic(
+    FFaker::IdentificationPL,
+    :pesel, :identity_card, :drivers_license
+  )
+
+  def setup
+    @tester = FFaker::IdentificationPL
+  end
+
+  def test_pesel
+    assert_match(/\A\d{11}\z/, @tester.pesel)
+  end
+
+  def test_identity_card
+    assert_match(/\A[A-Z]{3}\d{6}\z/, @tester.identity_card)
+  end
+
+  def test_drivers_license
+    assert_match(%r{\A\d{5}/\d{2}/\d{4}\z}, @tester.drivers_license)
+  end
+end


### PR DESCRIPTION
Added a new `FFaker::IdentificationPL` module for generating Polish identification numbers.
The following methods are available:
* `pesel` - generates a [PESEL](https://en.wikipedia.org/wiki/PESEL) - Polish national identification number
* `identity_card` - generates a [Polish identity card](https://en.wikipedia.org/wiki/Polish_identity_card) number
* `drivers_license` - generates a [Polish driver's licence](https://en.wikipedia.org/wiki/Driving_licence_in_Poland) number