### PR TITLE
Add Polish sport disciplines.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -149,6 +149,7 @@
  * [FFaker::SSNSE](#ffakerssnse)
  * [FFaker::Skill](#ffakerskill)
  * [FFaker::Sport](#ffakersport)
+ * [FFaker::SportPL](#ffakersportpl)
  * [FFaker::SportUS](#ffakersportus)
  * [FFaker::String](#ffakerstring)
  * [FFaker::Time](#ffakertime)
@@ -2242,6 +2243,14 @@
 | Method | Example |
 | ------ | ------- |
 | `name` | ❗ *[name] is deprecated. For US sports please use the SportUS module* |
+
+## FFaker::SportPL
+
+| Method | Example |
+| ------ | ------- |
+| `name` | Siatkówka plażowa, Saneczkarstwo, Szachy |
+| `summer` | Rzut dyskiem, Wioślarstwo, Żeglarstwo |
+| `winter` | Narciarstwo alpejskie, Dwubój zimowy, Łyżwiarstwo figurowe |
 
 ## FFaker::SportUS
 

--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -182,6 +182,7 @@ module FFaker
   autoload :SemVer, 'ffaker/sem_ver'
   autoload :Skill, 'ffaker/skill'
   autoload :Sport, 'ffaker/sport'
+  autoload :SportPL, 'ffaker/sport_pl'
   autoload :SportUS, 'ffaker/sport_us'
   autoload :SSN, 'ffaker/ssn'
   autoload :SSNMX, 'ffaker/ssn_mx'

--- a/lib/ffaker/data/sport_pl/summer
+++ b/lib/ffaker/data/sport_pl/summer
@@ -1,0 +1,53 @@
+Badminton
+Baseball
+Biegi płotkarski
+Bule
+Dżudo
+Futbol amerykański
+Gimnastyka artystyczna
+Gimnastyka sportowa
+Golf
+Hokej na trawie
+Jeździectwo
+Kajakarstwo górskie
+Kajakarstwo regatowe
+Kolarstwo szosowe
+Kolarstwo torowe
+Koszykówka
+Krykiet
+Lacrosse
+Łucznictwo
+Pchnięcie kulą
+Pięciobój nowoczesny
+Pięściarstwo
+Piłka nożna
+Piłka ręczna
+Piłka wodna
+Pływanie synchroniczne
+Podnoszenie ciężarów
+Poker
+Polo
+Rugby
+Rzut dyskiem
+Rzut młotem
+Rzut oszczepem
+Siatkówka
+Siatkówka plażowa
+Skok o tyczce
+Skok w dal
+Skok wzwyż
+Skoki do wody
+Squash
+Strzelectwo
+Szachy
+Szermierka
+Taekwondo
+Tenis stołowy
+Tenis ziemny
+Trójbój
+Trójskok
+Unihokej
+Wędkarstwo
+Wioślarstwo
+Zapasy
+Żeglarstwo

--- a/lib/ffaker/data/sport_pl/winter
+++ b/lib/ffaker/data/sport_pl/winter
@@ -1,0 +1,14 @@
+Biegi narciarskie
+Bobsleje
+Curling
+Dwubój zimowy
+Hokej na lodzie
+Kombinacja norweska
+Łyżwiarstwo figurowe
+Łyżwiarstwo szybkie
+Narciarstwo alpejskie
+Narciarstwo dowolne
+Saneczkarstwo
+Skeleton
+Skoki narciarskie
+Snowboarding

--- a/lib/ffaker/sport_pl.rb
+++ b/lib/ffaker/sport_pl.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FFaker
+  # Inspirations:
+  # https://pl.wikipedia.org/wiki/Kategoria:Dyscypliny_sportowe
+  # https://pl.wikipedia.org/wiki/Igrzyska_olimpijskie
+  module SportPL
+    extend ModuleUtils
+    extend self
+
+    ALL = SUMMER + WINTER
+
+    def name
+      fetch_sample(ALL)
+    end
+
+    def summer
+      fetch_sample(SUMMER)
+    end
+
+    def winter
+      fetch_sample(WINTER)
+    end
+  end
+end

--- a/test/test_sport_pl.rb
+++ b/test/test_sport_pl.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+class TestSportPL < Test::Unit::TestCase
+  include DeterministicHelper
+
+  assert_methods_are_deterministic(
+    FFaker::SportPL,
+    :name,
+    :summer,
+    :winter
+  )
+
+  def setup
+    @tester = FFaker::SportPL
+  end
+
+  def test_name
+    assert_include(@tester::ALL, @tester.name)
+  end
+
+  def test_summer
+    assert_include(@tester::SUMMER, @tester.summer)
+  end
+
+  def test_winter
+    assert_include(@tester::WINTER, @tester.winter)
+  end
+end


### PR DESCRIPTION
Added a new `FFaker::SportPL` module for generating Polish names of sport disciplines.
The following methods are introduced:
* `names` - returns a sport name
* `summer` - returns a name of summer sport discipline
* `winter` - returns a name of winter sport discipline