### PR TITLE
Remove deprecated RubyForge from GemSpec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,10 +42,6 @@ def date
   Date.today.to_s
 end
 
-def rubyforge_project
-  name
-end
-
 def gemspec_file
   "#{name}.gemspec"
 end
@@ -121,8 +117,6 @@ task gemspec: :validate do
   replace_header(head, :name)
   replace_header(head, :version)
   replace_header(head, :date)
-  # comment this out if your rubyforge_project has a different name
-  replace_header(head, :rubyforge_project)
 
   # determine file list from git ls-files
   files = `git ls-files`

--- a/ffaker.gemspec
+++ b/ffaker.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.name              = 'ffaker'
   s.version           = '2.13.0'
   s.date              = '2019-10-04'
-  s.rubyforge_project = 'ffaker'
   s.required_ruby_version = '>= 2.4'
 
   s.license = 'MIT'


### PR DESCRIPTION
> NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.