### PR TITLE
Resolve security alert about `rake`

### DIFF
--- a/ffaker.gemspec
+++ b/ffaker.gemspec
@@ -42,6 +42,6 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir['test/**/*']
 
-  s.add_development_dependency 'rake', '~> 10.1.1'
+  s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
We don't need for Ruby 1.9 support for a long time.