### PR TITLE
Improve benchmark file

### DIFF
--- a/scripts/benchmark.rb
+++ b/scripts/benchmark.rb
@@ -7,9 +7,8 @@ NAMES_COUNT = 10_000
 def run(name)
   Benchmark.bm do |rep|
     rep.report("generating #{NAMES_COUNT} names (#{name})") do
-      NAMES_COUNT.times do
-        name == 'ffaker' ? FFaker::Name.name : Faker::Name.name
-      end
+      mod == 'ffaker' ? FFaker : Faker
+      NAMES_COUNT.times { mod::Name.name }
     end
   end
 end

--- a/scripts/benchmark.rb
+++ b/scripts/benchmark.rb
@@ -1,22 +1,20 @@
 # frozen_string_literal: true
 
-require 'rubygems'
 require 'benchmark'
 
-N = 10_000
+NAMES_COUNT = 10_000
 
 def run(name)
-  require name
   Benchmark.bm do |rep|
-    rep.report("generating #{N} names (#{name} #{FFaker::VERSION})") do
-      N.times do
-        FFaker::Name.name
+    rep.report("generating #{NAMES_COUNT} names (#{name})") do
+      NAMES_COUNT.times do
+        name == 'ffaker' ? FFaker::Name.name : Faker::Name.name
       end
     end
   end
-  $stdout.flush
-  exit(0)
 end
 
-fork { run('faker') }; Process.wait
-fork { run('ffaker') }; Process.wait
+['faker', 'ffaker'].each do |gem_name|
+  require gem_name
+  fork { run(gem_name) }; Process.wait
+end


### PR DESCRIPTION
Improved benchmark file since it was raising some errors (for example, it called only FFaker's method, even on run with only requiring gem Faker).
Good news for FFaker: it still has better performance!

My runs:
```bash
       user     system      total        real
generating 10000 names (faker)  1.559069   0.023993   1.583062 (  1.583429)
       user     system      total        real
generating 10000 names (ffaker)  0.029849   0.000000   0.029849 (  0.029844)
```

```bash
       user     system      total        real
generating 10000 names (faker)  1.592440   0.012006   1.604446 (  1.604519)
       user     system      total        real
generating 10000 names (ffaker)  0.030299   0.000000   0.030299 (  0.030329)
```

```bash
       user     system      total        real
generating 10000 names (faker)  1.481379   0.020025   1.501404 (  1.501506)
       user     system      total        real
generating 10000 names (ffaker)  0.021874   0.007457   0.029331 (  0.029317)
```