### PR TITLE
Improve CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
-sudo: false
+os: linux
+dist: xenial
 rvm:
  - 2.4
  - 2.5


### PR DESCRIPTION
There was some warnings in CI for #434 .
[Example](https://travis-ci.org/github/ffaker/ffaker/builds/667901664/config)
```
Build config validation 
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing dist, using the default xenial
root: missing os, using the default linux
```