### PR TITLE
# US Country name & code updated.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -817,6 +817,8 @@
 | `street_name` | Mike Plain, Wisozk Ports, Zaida Causeway |
 | `street_suffix` | Mall, Harbor, Track |
 | `time_zone` | Pacific/Midway, Europe/Bratislava, Asia/Muscat |
+| `country` | United States |
+| `country_code` | US |
 | `uk_country` | ❗ *[uk_country] is deprecated. For UK addresses please use the AddressUK module* |
 | `uk_county` | ❗ *[uk_county] is deprecated. For UK addresses please use the AddressUK module* |
 | `uk_postcode` | ❗ *[uk_postcode] is deprecated. For UK addresses please use the AddressUK module* |

--- a/lib/ffaker/address_us.rb
+++ b/lib/ffaker/address_us.rb
@@ -41,6 +41,14 @@ module FFaker
       fetch_sample(CONTINENTAL_STATE_ABBR)
     end
 
+    def country
+      FFaker::Address.country('US')
+    end
+
+    def country_code
+      FFaker::Address.country_code('United States')
+    end
+
     private
 
     def check_state_existence(state_name)

--- a/test/test_address_us.rb
+++ b/test/test_address_us.rb
@@ -48,4 +48,12 @@ class TestAddressUSUS < Test::Unit::TestCase
   def test_zip_code_frozen
     assert FFaker::AddressUS.zip_code.frozen? == false
   end
+
+  def test_country
+    assert_equal 'United States', FFaker::AddressUS.country
+  end
+
+  def test_country_code
+    assert_equal 'US', FFaker::AddressUS.country_code
+  end
 end


### PR DESCRIPTION
Recently when using `US` Country FFaker, identified that the `country` & `country_code` values were random. submitting this improvement. Please feel free to post a feedback.