### PR TITLE
Make sure dutch zipcodes never start with a 0

### DIFF
--- a/lib/ffaker/address_nl.rb
+++ b/lib/ffaker/address_nl.rb
@@ -12,7 +12,7 @@ module FFaker
     POSTAL_CODE_FORMAT = ['#### ??'].freeze
 
     def postal_code
-      FFaker.bothify(POSTAL_CODE_FORMAT).tap { |p| p[0] = rand(1..9).to_s }
+      FFaker::String.from_regexp(/[1-9]\d{3} [A-Z]{2}/)
     end
 
     def zip_code

--- a/lib/ffaker/address_nl.rb
+++ b/lib/ffaker/address_nl.rb
@@ -12,7 +12,7 @@ module FFaker
     POSTAL_CODE_FORMAT = ['#### ??'].freeze
 
     def postal_code
-      FFaker.bothify POSTAL_CODE_FORMAT
+      FFaker.bothify(POSTAL_CODE_FORMAT).tap { |p| p[0] = rand(1..9).to_s }
     end
 
     def zip_code

--- a/test/test_address_nl.rb
+++ b/test/test_address_nl.rb
@@ -23,7 +23,7 @@ class TestAddressNL < Test::Unit::TestCase
   end
 
   def test_zip_code
-    assert_match(/^\d{4}\s\w{2}$/, @tester.zip_code)
+    assert_match(/^[1-9]\d{3}\s\w{2}$/, @tester.zip_code)
   end
 
   def test_street_name

--- a/test/test_address_nl.rb
+++ b/test/test_address_nl.rb
@@ -23,7 +23,7 @@ class TestAddressNL < Test::Unit::TestCase
   end
 
   def test_zip_code
-    assert_match(/^[1-9]\d{3}\s\w{2}$/, @tester.zip_code)
+    assert_match(/\A[1-9]\d{3} [A-Z]{2}\z/, @tester.zip_code)
   end
 
   def test_street_name


### PR DESCRIPTION
I had a flipper spec that failed because the dutch zipcode did not always pass the mustar. A dutch  zipcode never starts with a 0.

For reference see the map at https://en.wikipedia.org/wiki/Postal_codes_in_the_Netherlands