### PR TITLE
Improved NL zipcode generation

### DIFF
--- a/lib/ffaker/address_nl.rb
+++ b/lib/ffaker/address_nl.rb
@@ -10,7 +10,7 @@ module FFaker
     extend self
 
     def postal_code
-      FFaker::String.from_regexp(/[1-9]\d{3} [A-Z]{2}/)
+      FFaker::String.from_regexp(/[1-9]\d{3} [A-RT-Z][A-Z]/)
     end
 
     def zip_code

--- a/test/test_address_nl.rb
+++ b/test/test_address_nl.rb
@@ -23,7 +23,7 @@ class TestAddressNL < Test::Unit::TestCase
   end
 
   def test_zip_code
-    assert_match(/\A[1-9]\d{3} ?(?!sa|sd|ss)[A-Z]{2}\z/, @tester.zip_code)
+    assert_match(/\A[1-9]\d{3} [A-RT-Z][A-Z]\z/, @tester.zip_code)
   end
 
   def test_street_name

--- a/test/test_address_nl.rb
+++ b/test/test_address_nl.rb
@@ -23,7 +23,7 @@ class TestAddressNL < Test::Unit::TestCase
   end
 
   def test_zip_code
-    assert_match(/\A[1-9]\d{3} [A-Z]{2}\z/, @tester.zip_code)
+    assert_match(/\A[1-9]\d{3} ?(?!sa|sd|ss)[A-Z]{2}\z/, @tester.zip_code)
   end
 
   def test_street_name


### PR DESCRIPTION
The letter combinations 'SS', 'SD' and 'SA' are not used because of their associations with the Nazi occupation of the Netherlands. To pass zipcode validations I removed ’S’ as a possible first letter in the regular expression.