### PR TITLE
fix require ffaker/version

### DIFF
--- a/lib/ffaker/utils/module_utils.rb
+++ b/lib/ffaker/utils/module_utils.rb
@@ -17,10 +17,15 @@ module FFaker
         super const_name
       else
         mod_name = ancestors.first.to_s.split('::').last
-        data_path = "#{FFaker::BASE_LIB_PATH}/ffaker/data/#{underscore(mod_name)}/#{underscore(const_name.to_s)}"
-        data = k File.read(data_path, mode: 'r:UTF-8').split("\n")
-        const_set const_name, data
-        data
+        if mod_name == 'FFaker'
+          require "#{FFaker::BASE_LIB_PATH}/#{underscore(const_name.to_s)}"
+          FFaker.const_get(const_name)
+        else
+          data_path = "#{FFaker::BASE_LIB_PATH}/ffaker/data/#{underscore(mod_name)}/#{underscore(const_name.to_s)}"
+          data = k File.read(data_path, mode: 'r:UTF-8').split("\n")
+          const_set const_name, data
+          data
+        end
       end
     end
 


### PR DESCRIPTION
Hi there!

Here in my company we are using [Sorbet](https://sorbet.org/) extensively for type checking, and we have recently found out [this gem tapioca](https://github.com/Shopify/tapioca) that analyzes statically all the gems specified in the Gemfile after requires all the files in each of them.

When we run `bundle exec tapioca sync` an error occurred with `ffaker`:
```
  Compiling ffaker, this may take a few seconds... bundler: failed to load command: tapioca (/usr/local/bundle/ruby/2.7.0/bin/tapioca)
Errno::ENOENT: No such file or directory @ rb_sysopen - /usr/local/bundle/ruby/2.7.0/gems/ffaker-2.16.0/lib/ffaker/data/f_faker/version
  /usr/local/bundle/ruby/2.7.0/gems/ffaker-2.16.0/lib/ffaker/utils/module_utils.rb:21:in `read'
  /usr/local/bundle/ruby/2.7.0/gems/ffaker-2.16.0/lib/ffaker/utils/module_utils.rb:21:in `const_missing'
```

It seems like there is some code calling `FFaker::VERSION`, but that constant is not defined in the _data_ folder, it is defined in `lib/version.rb` instead. Hence, we have made a small tweak to `FFaker::ModuleUtils.const_missing` to address that.

Now everything is working fine.