### PR TITLE
fix #463 issues with `FFaker::Image` module

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1324,7 +1324,7 @@
 | Method | Example |
 | ------ | ------- |
 | `file` | #&lt;File:0x000055e0d4ff5568&gt;, #&lt;File:0x000055e0d5039a60&gt;, #&lt;File:0x000055e0d5061f88&gt; |
-| `url` | https://via.placeholder.com/300x300/590da5/821cfb.png?text=, https://via.placeholder.com/300x300/e8d24a/43209f.png?text=, https://via.placeholder.com/300x300/1b374a/a2037d.png?text= |
+| `url` | https://dummyimage.com/300x300/590da5/821cfb.png?text=, https://dummyimage.com/300x300/e8d24a/43209f.png?text=, https://dummyimage.com/300x300/1b374a/a2037d.png?text= |
 
 ## FFaker::Internet
 

--- a/lib/ffaker/image.rb
+++ b/lib/ffaker/image.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'cgi'
 require 'tempfile'
 require 'open-uri'
 
@@ -18,11 +19,16 @@ module FFaker
       text_color = FFaker::Color.hex_code if text_color == :random
       text = CGI.escape(text.to_s)
 
-      "https://via.placeholder.com/#{size}/#{bg_color}/#{text_color}.#{format}?text=#{text}"
+      "https://dummyimage.com/#{size}/#{bg_color}/#{text_color}.#{format}?text=#{text}"
     end
 
     def file(size = '300x300', format = 'png', bg_color = :random, text_color = :random, text = nil)
-      download_file(url(size, format, bg_color, text_color, text))
+      uri = URI.parse(url(size, format, bg_color, text_color, text))
+      file = Tempfile.new('ffaker_image')
+      file.binmode
+      file << uri.open.read
+      file.close
+      File.new(file.path)
     end
 
     private
@@ -37,15 +43,6 @@ module FFaker
       return true if SUPPORTED_FORMATS.include?(format)
 
       raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}"
-    end
-
-    def download_file(url)
-      file = Tempfile.new('ffaker_image')
-      file.binmode
-      file << URI.open(url).read
-      file.close
-
-      File.new(file.path)
     end
   end
 end

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -5,7 +5,7 @@ require 'helper'
 class TestImage < Test::Unit::TestCase
   include DeterministicHelper
 
-  PLACEHOLDER = 'https://via.placeholder.com/'
+  PLACEHOLDER = 'https://dummyimage.com/'
 
   assert_methods_are_deterministic(FFaker::Image, :url)
 


### PR DESCRIPTION
Because placeholder.com is somehow unavailable for some clients, I changed the provider in order to fix #463 . Even when using HTTP without TLS. Luckily the `https://dummyimage.com` which I found in this article https://loremipsum.io/de/21-of-the-best-placeholder-image-generators has exactly the same interface. ☘️ 🎉 

# current result 

```sh
➜  ffaker git:(main) bin/console
irb(main):001:0> FFaker::Image.file(size = '300x300', format = 'jpg', bg_color = :random, text_color = :random, text =
 'foobar')

Errno::ENOENT (No such file or directory @ rb_sysopen - /Users/hmaack/workspace/ffaker/lib/ffaker/data/image/cgi) 
 ```

with `require 'cgi'` statement

```/bin/sh

➜  ffaker git:(main) ✗ bin/console
irb(main):001:0> FFaker::Image.file
`Net::OpenTimeout (execution expired)`
```

# new result

```sh
➜  ffaker git:(fix/missing-cgi-for-image-module) bin/console
irb(main):001:0> FFaker::Image.url
=> "https://dummyimage.com/300x300/cfcf31/4633fb.png?text="
irb(main):002:0> FFaker::Image.file('1x1')
=> #<File:/var/folders/rl/xrt7hm790_53qys_r3wgf6xm0000gn/T/ffaker_image20210215-4738-15tk28b>

irb(main):008:0> _.read
=> "\x89PNG\r\n\u001A\n\u0000\u0000\u0000\rIHDR\u0000\u0000\u0000\u0001\u0000\u0000\u0000\u0001\u0002\u0003\u0000\u0000\u0000b{,\u001A\u0000\u0000\u0000\tPLTEl1~\\\xD0TflnUʓ\xA3\u0000\u0000\u0000\tpHYs\u0000\u0000\u000E\xC4\u0000\u0000\u000E\xC4\u0001\x95+\u000E\e\u0000\u0000\u0000\nIDAT\b\x99ch\u0000\u0000\u0000\x82\u0000\x81\xCB\u0013\xB2a\u0000\u0000\u0000\u0000IEND\xAEB`\x82"
```

# tasks

- [x] add missing CGI require statement
- [x] use `URI.parse` instead of insecure `URI.open`
- [x] replace `placeholder.com` image provider with `dummyimage.com`
  because its somehow unavailable for some reason

