### PR TITLE
Rename CoursesFR's file to courses_fr.rb

### DIFF
--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -78,7 +78,7 @@ module FFaker
   autoload :CompanyJA, 'ffaker/company_ja'
   autoload :CompanySE, 'ffaker/company_se'
   autoload :Conference, 'ffaker/conference'
-  autoload :CoursesFR, 'ffaker/courses'
+  autoload :CoursesFR, 'ffaker/courses_fr'
   autoload :Currency, 'ffaker/currency'
   autoload :DizzleIpsum, 'ffaker/dizzle_ipsum'
   autoload :Education, 'ffaker/education'

--- a/lib/ffaker/courses_fr.rb
+++ b/lib/ffaker/courses_fr.rb
@@ -5,6 +5,7 @@ module FFaker
     module Mathematiques
       extend ModuleUtils
       extend self
+
       def lesson
         fetch_sample(LESSONS)
       end
@@ -13,6 +14,7 @@ module FFaker
     module Philosophie
       extend ModuleUtils
       extend self
+
       def lesson
         fetch_sample(LESSONS)
       end


### PR DESCRIPTION
Hi! Not a big deal, but a bit confusing that module CoursesFR has just courses.rb name. Renamed