### PR TITLE
Use `require_relative` where it's appropriate

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,8 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'ffaker'
 require 'irb'
+
+require_relative '../lib/ffaker'
 
 IRB.start

--- a/ffaker.gemspec
+++ b/ffaker.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './lib/version'
+require_relative 'lib/version'
 
 Gem::Specification.new do |s|
   s.specification_version = 2 if s.respond_to? :specification_version=

--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module FFaker
-  require 'ffaker/utils/array_utils'
-  require 'ffaker/utils/module_utils'
+  require_relative 'ffaker/utils/array_utils'
+  require_relative 'ffaker/utils/module_utils'
 
   extend ModuleUtils
 

--- a/lib/ffaker/address_au.rb
+++ b/lib/ffaker/address_au.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ffaker/address'
+require_relative 'address'
 
 module FFaker
   module AddressAU

--- a/lib/ffaker/address_br.rb
+++ b/lib/ffaker/address_br.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ffaker/address'
+require_relative 'address'
 
 module FFaker
   module AddressBR

--- a/lib/ffaker/address_ca.rb
+++ b/lib/ffaker/address_ca.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ffaker/address'
+require_relative 'address'
 
 module FFaker
   module AddressCA

--- a/lib/ffaker/freedom_ipsum.rb
+++ b/lib/ffaker/freedom_ipsum.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ffaker/lorem'
+require_relative 'lorem'
 
 module FFaker
   module FreedomIpsum

--- a/lib/ffaker/name_th_en.rb
+++ b/lib/ffaker/name_th_en.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ffaker/name_th'
+require_relative 'name_th'
 
 module FFaker
   module NameTHEN

--- a/lib/ffaker/utils/array_utils.rb
+++ b/lib/ffaker/utils/array_utils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ffaker/utils/random_utils'
+require_relative 'random_utils'
 
 module FFaker
   module ArrayUtils

--- a/lib/ffaker/utils/module_utils.rb
+++ b/lib/ffaker/utils/module_utils.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'ffaker/utils/array_utils'
-require 'ffaker/utils/random_utils'
-require 'ffaker/utils/unique_utils'
+require_relative 'array_utils'
+require_relative 'random_utils'
+require_relative 'unique_utils'
 
 module FFaker
   module ModuleUtils

--- a/scripts/profiling.rb
+++ b/scripts/profiling.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.dirname(__FILE__) + '/../lib/faker'
+require_relative '../lib/faker'
 
 N = 1_000_000
 

--- a/scripts/reference.rb
+++ b/scripts/reference.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH << File.dirname(__FILE__) + '/../lib'
-require 'ffaker'
+require_relative '../lib/ffaker'
 
 ICONS = {
   error: '‼️',

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test/unit'
-require 'ffaker'
+require_relative '../lib/ffaker'
 
 # Helpers for checking if a method is deterministic -- e.g., that the Random
 # results are repeatable given the same random seed.

--- a/test/test_address.rb
+++ b/test/test_address.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddress < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_au.rb
+++ b/test/test_address_au.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressAU < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_br.rb
+++ b/test/test_address_br.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressBR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_ca.rb
+++ b/test/test_address_ca.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressCA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_ch.rb
+++ b/test/test_address_ch.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressCHCH < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_ch_de.rb
+++ b/test/test_address_ch_de.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressCHDE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_ch_fr.rb
+++ b/test/test_address_ch_fr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressCHFR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_ch_it.rb
+++ b/test/test_address_ch_it.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressCHIT < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_da.rb
+++ b/test/test_address_da.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressDA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_de.rb
+++ b/test/test_address_de.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressDE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_fi.rb
+++ b/test/test_address_fi.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressFI < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_fr.rb
+++ b/test/test_address_fr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressFR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_gr.rb
+++ b/test/test_address_gr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressGR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_id.rb
+++ b/test/test_address_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressID < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_in.rb
+++ b/test/test_address_in.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressININ < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_ja.rb
+++ b/test/test_address_ja.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressJA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_kr.rb
+++ b/test/test_address_kr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressKR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_mx.rb
+++ b/test/test_address_mx.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressMX < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_nl.rb
+++ b/test/test_address_nl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressNL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_pl.rb
+++ b/test/test_address_pl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerAddressPL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_ru.rb
+++ b/test/test_address_ru.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressRU < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_se.rb
+++ b/test/test_address_se.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressSE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_sn.rb
+++ b/test/test_address_sn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressSn < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_ua.rb
+++ b/test/test_address_ua.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressUA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_uk.rb
+++ b/test/test_address_uk.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressUK < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_address_us.rb
+++ b/test/test_address_us.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAddressUSUS < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_airline.rb
+++ b/test/test_airline.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAirline < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_animal.rb
+++ b/test/test_animal.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAnimals < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_animal_cn.rb
+++ b/test/test_animal_cn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAnimalsCN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_animal_es.rb
+++ b/test/test_animal_es.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAnimalsES < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_animal_pl.rb
+++ b/test/test_animal_pl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAnimalsPL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_animal_us.rb
+++ b/test/test_animal_us.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAnimalsUS < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_array_utils.rb
+++ b/test/test_array_utils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestArrayUtils < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_avatar.rb
+++ b/test/test_avatar.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAvatar < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_aws.rb
+++ b/test/test_aws.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestAWS < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_bacon_ipsum.rb
+++ b/test/test_bacon_ipsum.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestBaconIpsum < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_bank.rb
+++ b/test/test_bank.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestBank < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_book.rb
+++ b/test/test_book.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestBook < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_boolean.rb
+++ b/test/test_boolean.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestBoolean < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_cheesy_lingo.rb
+++ b/test/test_cheesy_lingo.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCheesyLingo < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_code.rb
+++ b/test/test_code.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCode < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_color.rb
+++ b/test/test_color.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestColor < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_color_pl.rb
+++ b/test/test_color_pl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestColorPL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_color_ua.rb
+++ b/test/test_color_ua.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestColorUA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_company.rb
+++ b/test/test_company.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCompany < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_company_cn.rb
+++ b/test/test_company_cn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCompanyCN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_company_fr.rb
+++ b/test/test_company_fr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCompanyFR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_company_it.rb
+++ b/test/test_company_it.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCompanyIT < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_company_ja.rb
+++ b/test/test_company_ja.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCompanyJA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_company_se.rb
+++ b/test/test_company_se.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCompanySE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_conference.rb
+++ b/test/test_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestConference < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_course_mathematiques.rb
+++ b/test/test_course_mathematiques.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCourseMathematiques < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_course_philosophie.rb
+++ b/test/test_course_philosophie.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCoursePhilosophie < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_currency.rb
+++ b/test/test_currency.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCurrency < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_dizzle_ipsum.rb
+++ b/test/test_dizzle_ipsum.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestDizzleIpsum < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_education.rb
+++ b/test/test_education.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerEducation < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_education_cn.rb
+++ b/test/test_education_cn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerEducationCN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_ffaker.rb
+++ b/test/test_ffaker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFFaker < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_filesystem.rb
+++ b/test/test_filesystem.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerFilesystem < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_food.rb
+++ b/test/test_food.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerFood < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_food_pl.rb
+++ b/test/test_food_pl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerFoodPL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_freedom_ipsum.rb
+++ b/test/test_freedom_ipsum.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 class TestFreedomIpsum < Test::Unit::TestCase
   include DeterministicHelper
 

--- a/test/test_game.rb
+++ b/test/test_game.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestGame < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_gender.rb
+++ b/test/test_gender.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerGender < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_gender_br.rb
+++ b/test/test_gender_br.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerGenderBR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_gender_cn.rb
+++ b/test/test_gender_cn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerGenderCN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_gender_id.rb
+++ b/test/test_gender_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerGenderID < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_gender_ja.rb
+++ b/test/test_gender_ja.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerGenderJA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_gender_jp.rb
+++ b/test/test_gender_jp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerGenderJP < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_gender_kr.rb
+++ b/test/test_gender_kr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerGenderKR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_gender_pl.rb
+++ b/test/test_gender_pl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerGenderPL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_geolocation.rb
+++ b/test/test_geolocation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestGeolocation < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_guid.rb
+++ b/test/test_guid.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestGuid < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_healthcare_ipsum.rb
+++ b/test/test_healthcare_ipsum.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestHealthcareIpsum < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_healthcare_ru.rb
+++ b/test/test_healthcare_ru.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestHealthcareRU < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_hipster_ipsum.rb
+++ b/test/test_hipster_ipsum.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestHipsterIpsum < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_html_ipsum.rb
+++ b/test/test_html_ipsum.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestHTMLIpsum < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_identification.rb
+++ b/test/test_identification.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerIdentification < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_identification_br.rb
+++ b/test/test_identification_br.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerIdentificationBR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_identification_co.rb
+++ b/test/test_identification_co.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerIdentificationESCO < Test::Unit::TestCase
   include Test::Unit::Assertions

--- a/test/test_identification_es.rb
+++ b/test/test_identification_es.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerIdentificationES < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_identification_es_cl.rb
+++ b/test/test_identification_es_cl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerIdentificationESCL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_identification_es_mx.rb
+++ b/test/test_identification_es_mx.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestIdentificationMX < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_identification_in.rb
+++ b/test/test_identification_in.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestIdentificationIN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_identification_kr.rb
+++ b/test/test_identification_kr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerIdentificationKr < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_identification_tw.rb
+++ b/test/test_identification_tw.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerIdentificationTW < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestImage < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_internet.rb
+++ b/test/test_internet.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerInternet < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_internet_se.rb
+++ b/test/test_internet_se.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerInternetSE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_job.rb
+++ b/test/test_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerJob < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_job_br.rb
+++ b/test/test_job_br.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerJobBR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_job_cn.rb
+++ b/test/test_job_cn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerJobCN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_job_fr.rb
+++ b/test/test_job_fr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerJobFr < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_job_ja.rb
+++ b/test/test_job_ja.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerJobJA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_job_kr.rb
+++ b/test/test_job_kr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerJobKR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_job_vn.rb
+++ b/test/test_job_vn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerJobVN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_locale.rb
+++ b/test/test_locale.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLocale < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem.rb
+++ b/test/test_lorem.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLorem < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_ar.rb
+++ b/test/test_lorem_ar.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLoremARAR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_br.rb
+++ b/test/test_lorem_br.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLoremBR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_cn.rb
+++ b/test/test_lorem_cn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLoremCN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_fr.rb
+++ b/test/test_lorem_fr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLoremFR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_ie.rb
+++ b/test/test_lorem_ie.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLoremIE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_ja.rb
+++ b/test/test_lorem_ja.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLoremJA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_kr.rb
+++ b/test/test_lorem_kr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLoremKR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_pl.rb
+++ b/test/test_lorem_pl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerLoremPL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_ru.rb
+++ b/test/test_lorem_ru.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLoremRU < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_lorem_ua.rb
+++ b/test/test_lorem_ua.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestLoremUA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_module_utils.rb
+++ b/test/test_module_utils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestModuleUtils < Test::Unit::TestCase
   def test_provides_a_k_method_for_generating_constant_arrays

--- a/test/test_movie.rb
+++ b/test/test_movie.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestMovie < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_music.rb
+++ b/test/test_music.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestMusic < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name.rb
+++ b/test/test_name.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerName < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_ar.rb
+++ b/test/test_name_ar.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameAR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_br.rb
+++ b/test/test_name_br.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameBR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_cn.rb
+++ b/test/test_name_cn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameCN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_cs.rb
+++ b/test/test_name_cs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameCS < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_da.rb
+++ b/test/test_name_da.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameDA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_de.rb
+++ b/test/test_name_de.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameDE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_es.rb
+++ b/test/test_name_es.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameES < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_fr.rb
+++ b/test/test_name_fr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameFR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_ga.rb
+++ b/test/test_name_ga.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameGa < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_gr.rb
+++ b/test/test_name_gr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameGR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_id.rb
+++ b/test/test_name_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameID < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_it.rb
+++ b/test/test_name_it.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameIT < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_ja.rb
+++ b/test/test_name_ja.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameJA < Test::Unit::TestCase
   class << self

--- a/test/test_name_kh.rb
+++ b/test/test_name_kh.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameKH < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_kr.rb
+++ b/test/test_name_kr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameKR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_mx.rb
+++ b/test/test_name_mx.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameMX < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_nb.rb
+++ b/test/test_name_nb.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameNB < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_nl.rb
+++ b/test/test_name_nl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameNL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_ph.rb
+++ b/test/test_name_ph.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNamePH < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_pl.rb
+++ b/test/test_name_pl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNamePL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_ru.rb
+++ b/test/test_name_ru.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestNameRU < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_se.rb
+++ b/test/test_name_se.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameSE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_sn.rb
+++ b/test/test_name_sn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameSn < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_th.rb
+++ b/test/test_name_th.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameTH < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_th_en.rb
+++ b/test/test_name_th_en.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameTHEN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_tw.rb
+++ b/test/test_name_tw.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestFakerNameTW < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_ua.rb
+++ b/test/test_name_ua.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestNameUA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_name_vn.rb
+++ b/test/test_name_vn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestNameVN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_nato_alphabet.rb
+++ b/test/test_nato_alphabet.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestNato < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number.rb
+++ b/test/test_phone_number.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumber < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_au.rb
+++ b/test/test_phone_number_au.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberAU < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_br.rb
+++ b/test/test_phone_number_br.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberBR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_cu.rb
+++ b/test/test_phone_number_cu.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberCU < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_da.rb
+++ b/test/test_phone_number_da.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberDA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_de.rb
+++ b/test/test_phone_number_de.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberDE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_fr.rb
+++ b/test/test_phone_number_fr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberFR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_id.rb
+++ b/test/test_phone_number_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberID < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_ja.rb
+++ b/test/test_phone_number_ja.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberJA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_kr.rb
+++ b/test/test_phone_number_kr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberKR < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_mx.rb
+++ b/test/test_phone_number_mx.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberMX < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_nl.rb
+++ b/test/test_phone_number_nl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberNL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_pl.rb
+++ b/test/test_phone_number_pl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberPL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_se.rb
+++ b/test/test_phone_number_se.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberSE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_sg.rb
+++ b/test/test_phone_number_sg.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberSG < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_sn.rb
+++ b/test/test_phone_number_sn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberSN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_tw.rb
+++ b/test/test_phone_number_tw.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberTW < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_phone_number_ua.rb
+++ b/test/test_phone_number_ua.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestPhoneNumberUA < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_products.rb
+++ b/test/test_products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestProducts < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_sem_ver.rb
+++ b/test/test_sem_ver.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestSemVer < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_skill.rb
+++ b/test/test_skill.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestSkill < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_sport_pl.rb
+++ b/test/test_sport_pl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestSportPL < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_sport_us.rb
+++ b/test/test_sport_us.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestSportUS < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_sports.rb
+++ b/test/test_sports.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestSports < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_ssn.rb
+++ b/test/test_ssn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestSSN < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_ssn_mx.rb
+++ b/test/test_ssn_mx.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestSSNMX < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_ssn_se.rb
+++ b/test/test_ssn_se.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestSSNSE < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_string.rb
+++ b/test/test_string.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestString < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 require 'date'
 
 class TestFakerTime < Test::Unit::TestCase

--- a/test/test_tweet.rb
+++ b/test/test_tweet.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestTweet < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_unique_utils.rb
+++ b/test/test_unique_utils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestUniqueUtils < Test::Unit::TestCase
   def test_generates_unique_values

--- a/test/test_units.rb
+++ b/test/test_units.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestUnits < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_units_english.rb
+++ b/test/test_units_english.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestUnitsEnglish < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_units_metric.rb
+++ b/test/test_units_metric.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestUnitsMetric < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_vehicle.rb
+++ b/test/test_vehicle.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestVehicle < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_venue.rb
+++ b/test/test_venue.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestVenue < Test::Unit::TestCase
   include DeterministicHelper

--- a/test/test_youtube.rb
+++ b/test/test_youtube.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class YoutubeTest < Test::Unit::TestCase
   include DeterministicHelper


### PR DESCRIPTION
We can be sure that use correct files instead of global installed version.