### PR TITLE
Fix loadError on scripts/reference.rb

### DIFF
--- a/.github/workflows/reference.yml
+++ b/.github/workflows/reference.yml
@@ -18,7 +18,7 @@ jobs:
         ruby-version: 2.6
         bundler-cache: true
     - name: Update md file
-      run: rake reference
+      run: bundle exec rake reference
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Update reference


### PR DESCRIPTION
Error message was:
```
Run rake reference
/opt/hostedtoolcache/Ruby/2.6.7/x64/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- ffaker/aws (LoadError)
	from /opt/hostedtoolcache/Ruby/2.6.7/x64/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from ./scripts/reference.rb:13:in `const_get'
	from ./scripts/reference.rb:13:in `block in faker_modules'
	from ./scripts/reference.rb:12:in `map'
	from ./scripts/reference.rb:12:in `faker_modules'
	from ./scripts/reference.rb:49:in `<main>'
```

The `autoload` use same logic with `require` means. It require `lib` directory in $LOAD_PATH so, I just run it with bundle exec