### PR TITLE
Fix gem autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ FFaker::Name.unique.name
   (if you want to have your own version, that is fine but bump version in a commit by itself I can ignore when I pull)
 * Send me a pull request. Bonus points for topic branches.
 
+### Running tests
+On a single file:
+```ruby
+ruby test/test_file.rb
+```
+
+Run all tests:
+```ruby
+for file in test/test_*.rb; do ruby $file; done
+```
+
 ## Release
 
 * Bump version in `lib/version.rb`.

--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -6,6 +6,8 @@ module FFaker
 
   extend ModuleUtils
 
+  $LOAD_PATH << File.join(File.dirname(__FILE__))
+
   BASE_LIB_PATH = File.expand_path(__dir__)
 
   LETTERS = Array('a'..'z').freeze

--- a/test/test_name_id.rb
+++ b/test/test_name_id.rb
@@ -16,7 +16,7 @@ class TestFakerNameID < Test::Unit::TestCase
   end
 
   def test_name
-    assert_match(/\A[a-zA-Z\s]+\z/, @tester.name)
+    assert_match(/\A[a-zA-Z\s'`]+\z/, @tester.name)
   end
 
   def test_name_with_prefix


### PR DESCRIPTION
`autoload` doesn't seem to be able to require files relative to its directory, unless this directory is required as well. Addition of gem's root directory to $LOAD_PATH seems to fix it.

Also, I added an instruction how to run all tests at once, since there seems to be a lot of red tests.