### PR TITLE
Remove date from gem specification

### DIFF
--- a/ffaker.gemspec
+++ b/ffaker.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
 
   s.name              = 'ffaker'
   s.version           = FFaker::VERSION
-  s.date              = '2021-08-17'
   s.required_ruby_version = '>= 2.5'
 
   s.license = 'MIT'


### PR DESCRIPTION
It has default value and not even in the current gemspec documntation.