### PR TITLE
Add neighborhood and address complement to AddressBR

### DIFF
--- a/lib/ffaker/address_br.rb
+++ b/lib/ffaker/address_br.rb
@@ -42,11 +42,16 @@ module FFaker
       FFaker.numerify(fetch_sample(COMPLEMENT))
     end
 
+    def neighborhood
+      prefix = fetch_sample(NEIGHBORHOOD_PREFIXES)
+      "#{prefix} #{NameBR.first_name}"
+    end
+
     def full_address(with_complement: false)
       if with_complement
-        "#{street}, #{building_number}, #{complement}, #{city}, #{state}, Brazil"
+        "#{street}, #{building_number}, #{complement}, #{neighborhood}, #{city}, #{state}, Brazil"
       else
-      "#{street}, #{building_number}, #{city}, #{state}, Brazil"
+      "#{street}, #{building_number}, #{neighborhood}, #{city}, #{state}, Brazil"
       end
     end
 

--- a/lib/ffaker/address_br.rb
+++ b/lib/ffaker/address_br.rb
@@ -37,9 +37,18 @@ module FFaker
       when 1 then "#{street_prefix} #{NameBR.first_name} #{NameBR.last_name} #{NameBR.last_name}"
       end
     end
-
-    def full_address
-      "#{street}, #{building_number}, #{city}, #{state}, Brazil"
+    
+    def complement
+      FFaker.numerify(fetch_sample(COMPLEMENT))
     end
+
+    def full_address(with_complement: false)
+      if with_complement
+        "#{street}, #{building_number}, #{complement}, #{city}, #{state}, Brazil"
+      else
+      "#{street}, #{building_number}, #{city}, #{state}, Brazil"
+      end
+    end
+
   end
 end

--- a/lib/ffaker/data/address_br/complement
+++ b/lib/ffaker/data/address_br/complement
@@ -1,0 +1,3 @@
+Apartamento ###
+Casa Térrea
+Fundos

--- a/lib/ffaker/data/address_br/neighborhood_prefixes
+++ b/lib/ffaker/data/address_br/neighborhood_prefixes
@@ -1,0 +1,3 @@
+Vila
+Parque
+Jardim

--- a/test/test_address_br.rb
+++ b/test/test_address_br.rb
@@ -34,4 +34,9 @@ class TestAddressBR < Test::Unit::TestCase
     prefixes = FFaker::AddressBR::STREET_PREFIX
     assert_match(/(#{prefixes.join('|')})( \p{Alpha}+){1,2}/, FFaker::AddressBR.street)
   end
+
+  def test_complement
+    assert FFaker::AddressBR::COMPLEMENT.include?(FFaker::AddressBR.complement)
+  end
+
 end

--- a/test/test_address_br.rb
+++ b/test/test_address_br.rb
@@ -39,4 +39,9 @@ class TestAddressBR < Test::Unit::TestCase
     assert FFaker::AddressBR::COMPLEMENT.include?(FFaker::AddressBR.complement)
   end
 
+  def test_neighborhood
+    neighborhood_prefix = FFaker::AddressBR.neighborhood.split(' ').first
+    assert FFaker::AddressBR::NEIGHBORHOOD_PREFIXES.include?(neighborhood_prefix)
+  end
+
 end


### PR DESCRIPTION
I've added two methods to the AddressBR module:

- Neighborhood: A method to generate brazilian neighborhood names using the most common prefixes

- Complement: A method to generate complement to the addresses, most brazilian e-commerces/stores/information systems use the complement as a secondary address e.g: Apartment 104, Shed

Can you please add the `hacktoberfest-accepted` tag to this PR? It's my first contribution :D