### PR TITLE
Ensure FFaker::HTMLIpsum.fancy_string return includes at least one tag

### DIFF
--- a/lib/ffaker/html_ipsum.rb
+++ b/lib/ffaker/html_ipsum.rb
@@ -136,7 +136,7 @@ module FFaker
         content_tag_for(:em, paragraph),
         content_tag_for(:code, words(2)),
         (a 2).to_s
-      ] + FFaker::Lorem.paragraphs(count))
+      ] + FFaker::Lorem.paragraphs(count - 1))
       fetch_sample(a, count: count).join(sep)
     end
 

--- a/lib/ffaker/html_ipsum.rb
+++ b/lib/ffaker/html_ipsum.rb
@@ -134,7 +134,13 @@ module FFaker
       a = k([
         content_tag_for(:strong, words(2).capitalize!),
         content_tag_for(:em, paragraph),
+        content_tag_for(:mark, paragraph),
+        content_tag_for(:del, words(2)),
+        content_tag_for(:ins, words(2)),
+        content_tag_for(:sub, words(2)),
+        content_tag_for(:sup, words(2)),
         content_tag_for(:code, words(2)),
+        content_tag_for(:small, words(2)),
         (a 2).to_s
       ] + FFaker::Lorem.paragraphs(count - 1))
       fetch_sample(a, count: count).join(sep)

--- a/test/test_html_ipsum.rb
+++ b/test/test_html_ipsum.rb
@@ -90,6 +90,11 @@ class TestHTMLIpsum < Test::Unit::TestCase
     assert FFaker::HTMLIpsum.fancy_string.length > 1, 'the string is longer than one char'
   end
 
+  def test_fancy_string_tags
+    # It returns a string with at least one HTML tag
+    assert_match(%r{(<\w+>[\w\s]+<\/\w+>){1}}i, FFaker::HTMLIpsum.fancy_string(3))
+  end
+
   def test_fancy_string_breaks
     # We can't reliably predict what's going to end up inside, so just ensure
     # that we have a complete string.

--- a/test/test_html_ipsum.rb
+++ b/test/test_html_ipsum.rb
@@ -92,7 +92,8 @@ class TestHTMLIpsum < Test::Unit::TestCase
 
   def test_fancy_string_tags
     # It returns a string with at least one HTML tag
-    assert_match(%r{(<\w+>[\w\s]+<\/\w+>){1}}i, FFaker::HTMLIpsum.fancy_string(3))
+    assert_match(%r{(<.*>[\w\s]+<\/\w+>){1}}i, FFaker::HTMLIpsum.fancy_string(1))
+    assert_match(%r{(<.*>[\w\s]+<\/\w+>){1}}i, FFaker::HTMLIpsum.fancy_string(3))
   end
 
   def test_fancy_string_breaks


### PR DESCRIPTION
Issue #500 

- Non HTML paragraphs limited to `count - 1`, giving way to at least one tag.
- Added more other text formatting tags