### PR TITLE
Generate valid VINs

### DIFF
--- a/lib/ffaker/vehicle.rb
+++ b/lib/ffaker/vehicle.rb
@@ -2,6 +2,70 @@
 
 module FFaker
   module Vehicle
+    module VIN
+      extend ModuleUtils
+      extend self
+
+      # https://en.wikibooks.org/wiki/Vehicle_Identification_Numbers_(VIN_codes)/World_Manufacturer_Identifier_(WMI)
+      VALID_WMI_REGIONS = [ ('A'..'C'), ('J'..'Z'), ('1'..'9') ].map(&:to_a).flatten
+
+      VALID_YEAR_CHARS = %w[
+        5 6 7 8 9 A B C D E F G H J K L M N P R S T V W X Y 1 2 3 4 5 6 7 8 9
+      ] # 2005-2039
+
+      # https://en.wikibooks.org/wiki/Vehicle_Identification_Numbers_(VIN_codes)/Check_digit
+      TRANSLITERATION_VALUES = {
+        A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8,
+        J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9,
+        S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9
+      }
+      POSITION_WEIGHTS = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2]
+
+      VALID_ALPHA = TRANSLITERATION_VALUES.keys.map(&:to_s)
+      VALID_ALPHANUMERIC = VALID_ALPHA + ('1'..'9').to_a
+
+      # Generate a VIN that is compliant with specifications of US Title 49 Section 565.15
+      # https://www.govinfo.gov/content/pkg/CFR-2019-title49-vol6/xml/CFR-2019-title49-vol6-part565.xml#seqnum565.15
+      #
+      # Position  Meaning
+      # 1-3       Manufacturer ID aka WMI (alpha and digits)
+      # 4-8       Vehicle Description ("For passenger cars ..[position 7].. shall be alphabetic")
+      # 9         Check Digit (0-9 or "X")
+      # 10        Year (see VIN_VALID_YEARS)
+      # 11        Plant of manufacture (alpha and digits)
+      # 12-17     Serial number (digits only)
+      #
+      # I, O and Q are NOT allowed. VIN_VALID_ALPHA has valid alpha characters.
+      def vin
+        generated_vin = [
+          [ # Manufacturer ID / WMI
+            fetch_sample(VALID_WMI_REGIONS),
+            2.times.map{ fetch_sample(VALID_ALPHANUMERIC) }.join
+          ].join,
+          [ # Vehicle Description
+            3.times.map{ fetch_sample(VALID_ALPHANUMERIC) }.join,
+            fetch_sample(VALID_ALPHA),
+            fetch_sample(VALID_ALPHANUMERIC)
+          ].join,
+          '0', # check digit placeholder
+          fetch_sample(VALID_YEAR_CHARS), # Year of Manufacture
+          fetch_sample(VALID_ALPHANUMERIC), # Plant ID
+          6.times.map{ rand(10).to_s }.join # Serial number
+        ].join
+
+        # Calculate the Check Digit
+        weighted_sum = generated_vin.chars.each_with_index.map{|char, idx|
+          (TRANSLITERATION_VALUES[char.to_sym] || char).to_i * POSITION_WEIGHTS[idx]
+        }.reduce(:+)
+
+        check_digit = weighted_sum % 11
+        check_digit = 'X' if check_digit == 10
+        generated_vin[8] = check_digit.to_s
+
+        generated_vin
+      end
+    end
+
     extend ModuleUtils
     extend self
 
@@ -9,26 +73,6 @@ module FFaker
     YEARS = Array('1900'..(::Time.now.year + 1).to_s).freeze
     TRANSMISSIONS_ABBR = %w[AT MT AM CVT].freeze
     CYLINDERS = %w[2 5 6 8].freeze
-
-
-
-    # https://en.wikibooks.org/wiki/Vehicle_Identification_Numbers_(VIN_codes)/World_Manufacturer_Identifier_(WMI)
-    VIN_VALID_WMI_REGIONS = [ ('A'..'C'), ('J'..'Z'), ('1'..'9') ].map(&:to_a).flatten
-
-    VIN_VALID_YEAR_CHARS = %w[
-      5 6 7 8 9 A B C D E F G H J K L M N P R S T V W X Y 1 2 3 4 5 6 7 8 9
-    ] # 2005-2039
-
-    # https://en.wikibooks.org/wiki/Vehicle_Identification_Numbers_(VIN_codes)/Check_digit
-    VIN_TRANSLITERATION_VALUES = {
-      A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8,
-      J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9,
-      S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9
-    }
-    VIN_POSITION_WEIGHTS = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2]
-
-    VIN_VALID_ALPHA = VIN_TRANSLITERATION_VALUES.keys.map(&:to_s)
-    VIN_VALID_ALPHANUMERIC = VIN_VALID_ALPHA + ('1'..'9').to_a
 
     def base_color
       FFaker::Color.name
@@ -56,45 +100,8 @@ module FFaker
       fetch_sample(TRIMS_LIST)
     end
 
-    # Generate a VIN that is compliant with specifications of US Title 49 Section 565.15
-    # https://www.govinfo.gov/content/pkg/CFR-2019-title49-vol6/xml/CFR-2019-title49-vol6-part565.xml#seqnum565.15
-    #
-    # Position  Meaning
-    # 1-3       Manufacturer ID aka WMI (alpha and digits)
-    # 4-8       Vehicle Description ("For passenger cars ..[position 7].. shall be alphabetic")
-    # 9         Check Digit (0-9 or "X")
-    # 10        Year (see VIN_VALID_YEARS)
-    # 11        Plant of manufacture (alpha and digits)
-    # 12-17     Serial number (digits only)
-    #
-    # I, O and Q are NOT allowed. VIN_VALID_ALPHA has valid alpha characters.
     def vin
-      generated_vin = [
-        [ # Manufacturer ID / WMI
-          fetch_sample(VIN_VALID_WMI_REGIONS),
-          2.times.map{ fetch_sample(VIN_VALID_ALPHANUMERIC) }.join
-        ].join,
-        [ # Vehicle Description
-          3.times.map{ fetch_sample(VIN_VALID_ALPHANUMERIC) }.join,
-          fetch_sample(VIN_VALID_ALPHA),
-          fetch_sample(VIN_VALID_ALPHANUMERIC)
-        ].join,
-        '0', # check digit placeholder
-        fetch_sample(VIN_VALID_YEAR_CHARS), # Year of Manufacture
-        fetch_sample(VIN_VALID_ALPHANUMERIC), # Plant ID
-        6.times.map{ rand(10).to_s }.join # Serial number
-      ].join
-
-      # Calculate the Check Digit
-      weighted_sum = generated_vin.chars.each_with_index.map{|char, idx|
-        (VIN_TRANSLITERATION_VALUES[char.to_sym] || char).to_i * VIN_POSITION_WEIGHTS[idx]
-      }.reduce(:+)
-
-      check_digit = weighted_sum % 11
-      check_digit = 'X' if check_digit == 10
-      generated_vin[8] = check_digit.to_s
-
-      generated_vin
+      VIN::vin
     end
 
     def year

--- a/lib/ffaker/vehicle.rb
+++ b/lib/ffaker/vehicle.rb
@@ -10,6 +10,26 @@ module FFaker
     TRANSMISSIONS_ABBR = %w[AT MT AM CVT].freeze
     CYLINDERS = %w[2 5 6 8].freeze
 
+
+
+    # https://en.wikibooks.org/wiki/Vehicle_Identification_Numbers_(VIN_codes)/World_Manufacturer_Identifier_(WMI)
+    VIN_VALID_WMI_REGIONS = [ ('A'..'C'), ('J'..'Z'), ('1'..'9') ].map(&:to_a).flatten
+
+    VIN_VALID_YEAR_CHARS = %w[
+      5 6 7 8 9 A B C D E F G H J K L M N P R S T V W X Y 1 2 3 4 5 6 7 8 9
+    ] # 2005-2039
+
+    # https://en.wikibooks.org/wiki/Vehicle_Identification_Numbers_(VIN_codes)/Check_digit
+    VIN_TRANSLITERATION_VALUES = {
+      A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8,
+      J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9,
+      S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9
+    }
+    VIN_POSITION_WEIGHTS = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2]
+
+    VIN_VALID_ALPHA = VIN_TRANSLITERATION_VALUES.keys.map(&:to_s)
+    VIN_VALID_ALPHANUMERIC = VIN_VALID_ALPHA + ('1'..'9').to_a
+
     def base_color
       FFaker::Color.name
     end
@@ -36,8 +56,45 @@ module FFaker
       fetch_sample(TRIMS_LIST)
     end
 
+    # Generate a VIN that is compliant with specifications of US Title 49 Section 565.15
+    # https://www.govinfo.gov/content/pkg/CFR-2019-title49-vol6/xml/CFR-2019-title49-vol6-part565.xml#seqnum565.15
+    #
+    # Position  Meaning
+    # 1-3       Manufacturer ID aka WMI (alpha and digits)
+    # 4-8       Vehicle Description ("For passenger cars ..[position 7].. shall be alphabetic")
+    # 9         Check Digit (0-9 or "X")
+    # 10        Year (see VIN_VALID_YEARS)
+    # 11        Plant of manufacture (alpha and digits)
+    # 12-17     Serial number (digits only)
+    #
+    # I, O and Q are NOT allowed. VIN_VALID_ALPHA has valid alpha characters.
     def vin
-      FFaker.bothify('1#???#####?######').upcase
+      generated_vin = [
+        [ # Manufacturer ID / WMI
+          fetch_sample(VIN_VALID_WMI_REGIONS),
+          2.times.map{ fetch_sample(VIN_VALID_ALPHANUMERIC) }.join
+        ].join,
+        [ # Vehicle Description
+          3.times.map{ fetch_sample(VIN_VALID_ALPHANUMERIC) }.join,
+          fetch_sample(VIN_VALID_ALPHA),
+          fetch_sample(VIN_VALID_ALPHANUMERIC)
+        ].join,
+        '0', # check digit placeholder
+        fetch_sample(VIN_VALID_YEAR_CHARS), # Year of Manufacture
+        fetch_sample(VIN_VALID_ALPHANUMERIC), # Plant ID
+        6.times.map{ rand(10).to_s }.join # Serial number
+      ].join
+
+      # Calculate the Check Digit
+      weighted_sum = generated_vin.chars.each_with_index.map{|char, idx|
+        (VIN_TRANSLITERATION_VALUES[char.to_sym] || char).to_i * VIN_POSITION_WEIGHTS[idx]
+      }.reduce(:+)
+
+      check_digit = weighted_sum % 11
+      check_digit = 'X' if check_digit == 10
+      generated_vin[8] = check_digit.to_s
+
+      generated_vin
     end
 
     def year

--- a/test/test_vehicle.rb
+++ b/test/test_vehicle.rb
@@ -41,7 +41,21 @@ class TestVehicle < Test::Unit::TestCase
   end
 
   def test_vin
-    assert_match(/\A[A-Z0-9]{17}\z/, FFaker::Vehicle.vin)
+    vin = FFaker::Vehicle.vin
+
+    assert_match(/\A[A-Z0-9]{17}\z/, vin)
+    assert_not_match(/[IOQ]/, vin) # VINs can't have these letters
+    assert_includes(FFaker::Vehicle::VIN_VALID_ALPHA, vin[6]) # passenger vehicle designator
+    assert_includes(FFaker::Vehicle::VIN_VALID_YEAR_CHARS, vin[9]) # check year character
+
+    # Validate checksum calculation using known value to avoid duplicating checksum-calc code here.
+    # Setting seed to 13 will return vin "YTLTGCX361X265942".
+    previous_random_seed = FFaker::Random.seed # record current seed
+    FFaker::Random.seed = 13
+    assert_match(FFaker::Vehicle.vin[8], '6')
+
+    # Return seed to previous value
+    FFaker::Random.seed = previous_random_seed
   end
 
   def test_drivetrain

--- a/test/test_vehicle.rb
+++ b/test/test_vehicle.rb
@@ -45,8 +45,8 @@ class TestVehicle < Test::Unit::TestCase
 
     assert_match(/\A[A-Z0-9]{17}\z/, vin)
     assert_not_match(/[IOQ]/, vin) # VINs can't have these letters
-    assert_includes(FFaker::Vehicle::VIN_VALID_ALPHA, vin[6]) # passenger vehicle designator
-    assert_includes(FFaker::Vehicle::VIN_VALID_YEAR_CHARS, vin[9]) # check year character
+    assert_includes(FFaker::Vehicle::VIN::VALID_ALPHA, vin[6]) # passenger vehicle designator
+    assert_includes(FFaker::Vehicle::VIN::VALID_YEAR_CHARS, vin[9]) # check year character
 
     # Validate checksum calculation using known value to avoid duplicating checksum-calc code here.
     # Setting seed to 13 will return vin "YTLTGCX361X265942".


### PR DESCRIPTION
Issue #310

Generate VINs that are compliant with FMVSS 115, Part 595 standard. Uses designated character set and format, and includes valid Check Digit.

The support code + constants for the VIN code is namespaced in to it's own module to avoid cluttering up the main file.

Note `test/test_vehicle.rb#test_vin` could be brittle and the expected checksum could change if they was the VIN is generated `FFaker::Vehicle::VIN::vin` is changed.