### PR TITLE
Add Ruby 3.1 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,12 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
     name: Ruby ${{ matrix.ruby }} test
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # 'bundle install' and cache
       - run: rake test


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.

In addition to adding the Ruby 3.1 entry to the CI matrix, this PR switches the setup-ruby action to the `ruby/setup-ruby` action which is what's supported going forward.