### PR TITLE
Fix crash in FFaker::Time#datetime when defining FFaker::Date module

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -54,6 +54,7 @@
  * [FFaker::Conference](#ffakerconference)
  * [FFaker::CoursesFR](#ffakercoursesfr)
  * [FFaker::Currency](#ffakercurrency)
+ * [FFaker::Date](#ffakerdate)
  * [FFaker::DizzleIpsum](#ffakerdizzleipsum)
  * [FFaker::Education](#ffakereducation)
  * [FFaker::EducationCN](#ffakereducationcn)
@@ -1060,6 +1061,14 @@
 | `code` | KHR, MXN, CNY |
 | `name` | Baht, Cape Verde Escudo, Boliviano Mvdol |
 | `symbol` | ¥, €, $ |
+
+## FFaker::Date
+
+| Method | Example |
+| ------ | ------- |
+| `between`(..., ...) | 2021-09-23 |
+| `backward` | 2021-09-23 |
+| `forward` | 2021-09-23 |
 
 ## FFaker::DizzleIpsum
 

--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -82,6 +82,7 @@ module FFaker
   autoload :Conference, 'ffaker/conference'
   autoload :CoursesFR, 'ffaker/courses_fr'
   autoload :Currency, 'ffaker/currency'
+  autoload :Date, 'ffaker/date'
   autoload :DizzleIpsum, 'ffaker/dizzle_ipsum'
   autoload :Education, 'ffaker/education'
   autoload :EducationCN, 'ffaker/education_cn'

--- a/lib/ffaker/date.rb
+++ b/lib/ffaker/date.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'date'
+
+module FFaker
+  module Date
+    extend FFaker::ModuleUtils
+    extend self
+
+    # Generates a random date between 2 dates
+    def between(from, to)
+      FFaker::Time.between(from, to).to_date
+    end
+
+    # Generates a random date up to `days` days in the past
+    def backward(days = 365)
+      from = ::Date.today - days
+      to   = ::Date.today - 1
+
+      between(from, to)
+    end
+
+    # Generates a random date up to `days` days in the future
+    def forward(days = 365)
+      from = ::Date.today + 1
+      to   = ::Date.today + days
+
+      between(from, to)
+    end
+  end
+end

--- a/lib/ffaker/identification_es_co.rb
+++ b/lib/ffaker/identification_es_co.rb
@@ -32,7 +32,7 @@ module FFaker
     end
 
     def expedition_date
-      today = Date.today
+      today = ::Date.today
       today - rand(today.year)
     end
   end

--- a/lib/ffaker/identification_kr.rb
+++ b/lib/ffaker/identification_kr.rb
@@ -8,7 +8,7 @@ module FFaker
     # Resident Registration Number
     # http://ko.wikipedia.org/wiki/%EC%A3%BC%EB%AF%BC%EB%93%B1%EB%A1%9D%EB%B2%88%ED%98%B8
     def rrn
-      birth = fetch_sample(Date.new(1970, 1, 1)..Date.new(1999, 12, 31)).strftime('%y%d%m')
+      birth = fetch_sample(::Date.new(1970, 1, 1)..::Date.new(1999, 12, 31)).strftime('%y%d%m')
       sex = fetch_sample([1, 2])
       loc = FFaker.numerify("#{fetch_sample(Array('00'..'95'))}###")
       a, b, c, d, e, f, g, h, i, j, k, l = "#{birth}#{sex}#{loc}".split(//).map(&:to_i)

--- a/lib/ffaker/identification_pl.rb
+++ b/lib/ffaker/identification_pl.rb
@@ -37,8 +37,8 @@ module FFaker
     private
 
     def generate_valid_pesel_date
-      from = Date.new(1800, 1, 1)
-      to = [Date.today, Date.new(2299, 12, 31)].min
+      from = ::Date.new(1800, 1, 1)
+      to = [::Date.today, ::Date.new(2299, 12, 31)].min
       fetch_sample(from..to)
     end
 

--- a/lib/ffaker/time.rb
+++ b/lib/ffaker/time.rb
@@ -25,7 +25,7 @@ module FFaker
       latest_year = params[:year_latest] || 0
       year = (rand * years_back).ceil + (::DateTime.now.year - latest_year - years_back)
       month = rand(1..12)
-      day = rand(1..Date.new(year, month, -1).day)
+      day = rand(1..::Date.new(year, month, -1).day)
       hours = params[:hours] || rand(0..23)
       minutes = params[:minutes] || rand(0..59)
       series = [date = ::DateTime.new(year, month, day, hours, minutes)]

--- a/test/test_date.rb
+++ b/test/test_date.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+class TestFakerDate < Test::Unit::TestCase
+  include DeterministicHelper
+
+  def setup
+    @tester = FFaker::Date
+  end
+
+  assert_methods_are_deterministic(FFaker::Date, :backward, :forward)
+
+  def test_between
+    from = Date.new(2015, 1, 1)
+    to   = Date.new(2016, 12, 31)
+
+    assert_random_between(from..to) { @tester.between(from, to) }
+    assert_instance_of Date, @tester.between(from, to)
+  end
+
+  def test_backward
+    today = Date.today
+
+    assert_random_between(today - 365..today - 1) { @tester.backward }
+    assert_random_between(today - 30..today - 1) { @tester.backward(30) }
+    assert_instance_of Date, @tester.backward
+  end
+
+  def test_forward
+    today = Date.today
+
+    assert_random_between(today + 1..today + 365) { @tester.forward }
+    assert_random_between(today + 1..today + 30) { @tester.forward(30) }
+    assert_instance_of Date, @tester.forward
+  end
+end

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -3,13 +3,6 @@
 require_relative 'helper'
 require 'date'
 
-module FFaker
-  module Date
-    extend FFaker::ModuleUtils
-    extend self
-  end
-end
-
 class TestFakerTime < Test::Unit::TestCase
   include DeterministicHelper
 

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -3,6 +3,13 @@
 require_relative 'helper'
 require 'date'
 
+module FFaker
+  module Date
+    extend FFaker::ModuleUtils
+    extend self
+  end
+end
+
 class TestFakerTime < Test::Unit::TestCase
   include DeterministicHelper
 


### PR DESCRIPTION
Defining the FFaker::Date module makes FFaker::Time#datetime crash. 

When migrating from Faker, we needed to add the module FFaker::Date to handle #backward and #forward differently than FFaker::Time.

FFaker::Time#datetime uses Date.new instead of ::Date.new so it crashes on trying to instantiate FFaker::Date which is a module.