### PR TITLE
Added FFaker::Internet.uuid method to make uuids

### DIFF
--- a/lib/ffaker/internet.rb
+++ b/lib/ffaker/internet.rb
@@ -81,6 +81,14 @@ module FFaker
       rand(0...MAC_LIMIT).to_s(16).rjust(12, '0').scan(/.{2}/).join(delimiter)
     end
 
+    def uuid
+      # borrowed from: https://github.com/ruby/ruby/blob/d48783bb0236db505fe1205d1d9822309de53a36/lib/securerandom.rb#L250
+      ary = FFaker::Config.random.bytes(16).unpack('NnnnnN')
+      ary[2] = (ary[2] & 0x0fff) | 0x4000
+      ary[3] = (ary[3] & 0x3fff) | 0x8000
+      '%08x-%04x-%04x-%04x-%04x%08x' % ary # rubocop:disable Style/FormatString
+    end
+
     private
 
     def sanitize(string)

--- a/lib/ffaker/internet.rb
+++ b/lib/ffaker/internet.rb
@@ -82,11 +82,7 @@ module FFaker
     end
 
     def uuid
-      # borrowed from: https://github.com/ruby/ruby/blob/d48783bb0236db505fe1205d1d9822309de53a36/lib/securerandom.rb#L250
-      ary = FFaker::Config.random.bytes(16).unpack('NnnnnN')
-      ary[2] = (ary[2] & 0x0fff) | 0x4000
-      ary[3] = (ary[3] & 0x3fff) | 0x8000
-      '%08x-%04x-%04x-%04x-%04x%08x' % ary # rubocop:disable Style/FormatString
+      SecureRandom.uuid
     end
 
     private

--- a/test/test_internet.rb
+++ b/test/test_internet.rb
@@ -129,4 +129,10 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.mac(nil).length == 12
     assert @tester.mac('').length == 12
   end
+
+  def test_uuid
+    uuid = @tester.uuid
+    assert_equal(36, uuid.size)
+    assert_match(/\A\h{8}-\h{4}-4\h{3}-\h{4}-\h{12}\z/, uuid)
+  end
 end

--- a/test/test_internet.rb
+++ b/test/test_internet.rb
@@ -9,7 +9,7 @@ class TestFakerInternet < Test::Unit::TestCase
     FFaker::Internet,
     :email, :free_email, :safe_email, :disposable_email,
     :user_name, :domain_name, :domain_word, :domain_suffix,
-    :http_url, :ip_v4_address, :password, :slug, :mac
+    :http_url, :ip_v4_address, :password, :slug, :mac, :uuid
   )
 
   def setup


### PR DESCRIPTION
Copied from [Faker](https://github.com/faker-ruby/faker/). Adds FFaker::Internet.uuid method. Includes a test