### PR TITLE
adjust uniqueness handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,23 @@ name will be set with data from `ffaker/data/name/first_names`.
 
 To get repeatable results in Minitest or Rspec, follow [these instructions](RANDOM.md#using-the-same-random-seed-as-your-tests).
 
-## Unique results
+## Unique values
 
-You can get unique value from any methods in FFaker like this:
+You can ensure unique values are generated using the `unique` method. `ffaker` will retry the generation
+until an unique value if found.
 
-```rb
-FFaker::Name.unique.name
+Example:
+```ruby
+FFaker::Name.unique.name # ensures an unique value is returned for FFaker::Name
+```
+
+If an unique value cannot be generated within a maximum limit of retries for a generator
+a `FFaker::UniqueUtils::RetryLimitExceeded` error will be raised.
+
+You can prevent exceeding the limit by clearing the record of used values (e.g. between tests):
+```ruby
+FFaker::Name.unique.clear # clears the used values for FFaker::Name
+FFaker::UniqueUtils.clear # clears the used values for all generators
 ```
 
 ## TODO

--- a/lib/ffaker/utils/module_utils.rb
+++ b/lib/ffaker/utils/module_utils.rb
@@ -33,7 +33,7 @@ module FFaker
     end
 
     def unique(max_retries = 10_000)
-      @unique_generator ||= FFaker::UniqueUtils.new(self, max_retries)
+      FFaker::UniqueUtils.add_instance(self, max_retries)
     end
 
     # http://en.wikipedia.org/wiki/Luhn_algorithm

--- a/test/test_module_utils.rb
+++ b/test/test_module_utils.rb
@@ -11,4 +11,37 @@ class TestModuleUtils < Test::Unit::TestCase
     assert result.frozen?
     result.each { |e| assert e.frozen? }
   end
+
+  def test_unique
+    generator = Object.new
+    generator.extend FFaker::ModuleUtils
+    # returns [1 1 2 2 1 1 2 2 ..][call_index]
+    def generator.test
+      index = Thread.current[:test_unique] ||= 0
+      Thread.current[:test_unique] = (index > 2 ? 0 : index + 1)
+      (index / 2) + 1
+    end
+
+    assert_equal(1, generator.unique.test)
+    assert_equal(2, generator.unique.test)
+
+    Thread.new do
+      assert_equal(1, generator.unique.test)
+      assert_equal(2, generator.unique.test)
+
+      assert_raises FFaker::UniqueUtils::RetryLimitExceeded do
+        generator.unique.test
+      end
+
+      generator.unique.clear
+      generator.unique.test
+    end.join
+
+    assert_raises FFaker::UniqueUtils::RetryLimitExceeded do
+      generator.unique.test
+    end
+
+    FFaker::UniqueUtils.clear
+    generator.unique.test
+  end
 end

--- a/test/test_unique_utils.rb
+++ b/test/test_unique_utils.rb
@@ -39,16 +39,36 @@ class TestUniqueUtils < Test::Unit::TestCase
       unique_object.test
     end
 
-    FFaker::UniqueUtils.clear
-
-    assert_equal(1, unique_object.test)
-
-    assert_raises FFaker::UniqueUtils::RetryLimitExceeded do
-      unique_object.test
-    end
-
     unique_object.clear
 
     assert_equal(1, unique_object.test)
+  end
+
+  def test_clears_all_unique_values
+    stubbed_generator = Object.new
+    def stubbed_generator.test
+      1
+    end
+    other_stubbed_generator = Object.new
+    def other_stubbed_generator.test
+      1
+    end
+
+    unique_object = FFaker::UniqueUtils.add_instance(stubbed_generator, 3)
+    other_unique_object = FFaker::UniqueUtils.add_instance(other_stubbed_generator, 3)
+
+    [unique_object, other_unique_object].each do |tested_unique_object|
+      assert_equal(1, tested_unique_object.test)
+
+      assert_raises FFaker::UniqueUtils::RetryLimitExceeded do
+        tested_unique_object.test
+      end
+    end
+
+    FFaker::UniqueUtils.clear
+
+    [unique_object, other_unique_object].each do |tested_unique_object|
+      assert_equal(1, tested_unique_object.test)
+    end
   end
 end


### PR DESCRIPTION
- replace (slow) `ObjectSpace` with an instance record

   similar to https://github.com/faker-ruby/faker/pull/1246
  
  - before:
      ```ruby
      Benchmark.realtime { 100.times { FFaker::UniqueUtils.clear } }.to_d                                                                                                                                                                                                                             
       => 8.039850000059232
      ```
  
  - after: 
      ```ruby
      Benchmark.realtime { 100.times { FFaker::UniqueUtils.clear } }.to_d                                                                                                                                                                                                                        
      => 0.0000410000793635845
      ```

- implement thread safety

  Similar to https://github.com/faker-ruby/faker/pull/2520 but I've implemented it differently - I think this version is cleaner

- update README