### PR TITLE
Adds FFaker::Number.between

### DIFF
--- a/lib/ffaker/number.rb
+++ b/lib/ffaker/number.rb
@@ -15,6 +15,10 @@ module FFaker
       FFaker.numerify("#{whole_part_pattern}.#{fractional_part_pattern}").to_f
     end
 
+    def between(from: 1.00, to: 5000.00)
+      fetch_sample(from..to)
+    end
+
     private
 
     def generate_pattern(digits)

--- a/test/test_number.rb
+++ b/test/test_number.rb
@@ -5,7 +5,7 @@ require_relative 'helper'
 class TestNumber < Test::Unit::TestCase
   include DeterministicHelper
 
-  assert_methods_are_deterministic(FFaker::Number, :number, :decimal)
+  assert_methods_are_deterministic(FFaker::Number, :number, :decimal, :between)
 
   def setup
     @tester = FFaker::Number
@@ -41,5 +41,17 @@ class TestNumber < Test::Unit::TestCase
     assert_raise(ArgumentError.new('Digits cannot be less than 1')) do
       @tester.decimal(fractional_digits: 0)
     end
+  end
+
+  def test_between
+    from = -50
+    to = 50
+    assert_random_between(from..to) { @tester.between(from: from, to: to) }
+    assert_instance_of Integer, @tester.between(from: from, to: to)
+
+    from = -50.0
+    to = 50.0
+    assert_random_between(from..to) { @tester.between(from: from, to: to) }
+    assert_instance_of Float, @tester.between(from: from, to: to)
   end
 end


### PR DESCRIPTION
I'm on a project that has used both Faker and FFaker for a long time. We're now standardizing on FFaker. For much of the code, I'm able to use FFaker API calls. Occasionally, I come across a concept that I'd like to see in FFaker, hence this PR.

This adds a FFaker::Number.between(from: X, to: Y). These can be both integers or both floads.