### PR TITLE
Adds FFaker::Address.latitude and longitude

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
   - Add your change HERE
   - Update README [@professor]
+  - Added `FFaker::Address.latitude` and `FFaker::Address.longitude` [@professor]
   - Adds FFaker::Number.between [@professor]
   - Fixed `FFaker::Number.unique.number(digits: 1)` under Ruby 3 [@simonhildebrandt]
 

--- a/lib/ffaker/address.rb
+++ b/lib/ffaker/address.rb
@@ -111,5 +111,13 @@ module FFaker
     def time_zone
       fetch_sample(TIME_ZONE)
     end
+
+    def latitude
+      fetch_sample(-90.0..90.0)
+    end
+
+    def longitude
+      fetch_sample(-180.0..180.0)
+    end
   end
 end

--- a/test/test_address.rb
+++ b/test/test_address.rb
@@ -9,7 +9,7 @@ class TestAddress < Test::Unit::TestCase
     FFaker::Address,
     :building_number, :city, :city_prefix, :city_suffix, :secondary_address,
     :street_address, :street_name, :street_suffix, :neighborhood,
-    :country, :country_code, :time_zone
+    :country, :country_code, :time_zone, :latitude, :longitude
   )
 
   assert_methods_are_deterministic(
@@ -105,5 +105,13 @@ class TestAddress < Test::Unit::TestCase
 
   def test_time_zone
     assert_include FFaker::Address::TIME_ZONE, FFaker::Address.time_zone
+  end
+
+  def test_latitude
+    assert_match( /[\d\-\.]/, FFaker::Address.latitude.to_s)
+  end
+
+  def test_longitude
+    assert_match( /[\d\-\.]/, FFaker::Address.longitude.to_s)
   end
 end


### PR DESCRIPTION
I'm on a project that has used both Faker and FFaker for a long time. We're now standardizing on FFaker. For much of the code, I'm able to use FFaker API calls. Occasionally, I come across a concept that I'd like to see in FFaker, hence this PR.

This adds a FFaker::Address.latitude and longitude.