### PR TITLE
Adds FFaker::Number:leading_zero_number

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## development
 
   - Add your change HERE
+  - Adds FFaker::Number.leading_zero_number [@professor]
   - Update README [@professor]
   - Adds FFaker::Number.between [@professor]
   - Fixed `FFaker::Number.unique.number(digits: 1)` under Ruby 3 [@simonhildebrandt]

--- a/lib/ffaker/number.rb
+++ b/lib/ffaker/number.rb
@@ -15,6 +15,10 @@ module FFaker
       FFaker.numerify("#{whole_part_pattern}.#{fractional_part_pattern}").to_f
     end
 
+    def leading_zero_number(digits: 10)
+      FFaker.numerify("0#{"#" * (digits - 1)}")
+    end
+
     def between(from: 1.00, to: 5000.00)
       fetch_sample(from..to)
     end

--- a/test/test_number.rb
+++ b/test/test_number.rb
@@ -5,7 +5,7 @@ require_relative 'helper'
 class TestNumber < Test::Unit::TestCase
   include DeterministicHelper
 
-  assert_methods_are_deterministic(FFaker::Number, :number, :decimal, :between)
+  assert_methods_are_deterministic(FFaker::Number, :number, :decimal, :between, :leading_zero_number)
 
   def setup
     @tester = FFaker::Number
@@ -41,6 +41,14 @@ class TestNumber < Test::Unit::TestCase
     assert_raise(ArgumentError.new('Digits cannot be less than 1')) do
       @tester.decimal(fractional_digits: 0)
     end
+  end
+
+  def test_leading_zero
+    assert @tester.leading_zero_number.is_a?(String)
+    assert @tester.leading_zero_number.length == 10
+    assert @tester.leading_zero_number(digits: 3).length == 3
+    assert_match(/\A0\d{9}\z/, @tester.leading_zero_number.to_s)
+    assert_match(/\A0\d{2}\z/, @tester.leading_zero_number(digits: 3).to_s)
   end
 
   def test_between


### PR DESCRIPTION
I'm on a project that has used both Faker and FFaker for a long time. We're now standardizing on FFaker. For much of the code, I'm able to use FFaker API calls. Occasionally, I come across a concept that I'd like to see in FFaker, hence this PR.

This adds a FFaker::Number.leading_zero_number.

Note that this would return a string, not an integer. I'm not sure if that breaks any design constraints with FFaker (as compared to Faker). We only use it once, so I'm happy to inline the code in our app. I'm providing it here for anyone else transitioning from Faker to FFaker.
