### PR TITLE
Adds FFaker::Bank.routing_number and accounting_number

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 ## development
 
   - Add your change HERE
+  - Add FFaker::BankUS.accounting_number [@professor]
+  - Add FFaker::BankUS.routing_number [@professor]
   - Resolve a lot of RuboCop offenses [@AlexWayfer]
   - Change `Image.url`, `Image.file`, `Book.cover` and `Avatar.image` arguments to keywords [@AlexWayfer]
   - Adds FFaker::Date.birthday [@professor]

--- a/lib/ffaker/bank_us.rb
+++ b/lib/ffaker/bank_us.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module FFaker
+  module BankUS
+    extend ModuleUtils
+    extend self
+
+    def account_number(min_digits: 9, max_digits: 17)
+      FFaker.numerify('#' * rand(min_digits..max_digits))
+    end
+
+    def routing_number
+      partial_routing_number = FFaker.numerify('########')
+      ninth_digit = generate_ninth_digit(partial_routing_number)
+
+      "#{partial_routing_number}#{ninth_digit}"
+    end
+
+    private
+
+    def generate_ninth_digit(num_string)
+      # This leverages the `Modules 10, Straight Summation` used for routing_numbers
+      # See http://www.sxlist.com/techref/ecommerce/bank/routingnumber/index.htm
+      # for more details
+      num_array = num_string.chars.map(&:to_i)
+      (
+        (7 * (num_array[0] + num_array[3] + num_array[6])) +
+          (3 * (num_array[1] + num_array[4] + num_array[7])) +
+          (9 * (num_array[2] + num_array[5]))
+      ) % 10
+    end
+  end
+end

--- a/test/test_bank_us.rb
+++ b/test/test_bank_us.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+class TestBankUS < Test::Unit::TestCase
+  include DeterministicHelper
+
+  assert_methods_are_deterministic(
+    FFaker::BankUS,
+    :account_number, :routing_number
+  )
+
+  def setup
+    @tester = FFaker::BankUS
+  end
+
+  def test_account_number
+    assert_instance_of String, @tester.account_number
+    assert_match(/\A\d{8}\z/, @tester.account_number(min_digits: 8, max_digits: 8))
+    assert_match(/\A\d{12}\z/, @tester.account_number(min_digits: 12, max_digits: 12))
+  end
+
+  def test_routing_number
+    routing_number = @tester.routing_number
+    assert_match(/\A\d{9}\z/, routing_number)
+
+    checksum = (
+      (7 * (routing_number[0].to_i + routing_number[3].to_i + routing_number[6].to_i)) +
+        (3 * (routing_number[1].to_i + routing_number[4].to_i + routing_number[7].to_i)) +
+        (9 * (routing_number[2].to_i + routing_number[5].to_i + routing_number[8].to_i))
+    )
+
+    assert_equal(0, checksum % 10, 'The routing number\'s checksum is not a multiple of ten')
+  end
+end


### PR DESCRIPTION
This adds `FFaker::Bank.routing_number and accounting_number`

For our use case, we're looking for realistic looking US Bank account numbers and routing numbers. 
Accounting numbers can very between 9 and 17 digits [(Reference)](https://www.investopedia.com/articles/personal-finance/063015/routing-number-vs-account-number-how-they-differ.asp) Routing numbers have a checksum calculation on the last digit. 

