### PR TITLE
Constrain BankUS.routing_number's first two digits

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## development
 
   - Add your change HERE
+  - Limit FFaker::BankUS.routing_number first two digits [@professor]
 
 # 2.23.0
   - Add FFaker::BankUS.accounting_number [@professor]

--- a/lib/ffaker/bank_us.rb
+++ b/lib/ffaker/bank_us.rb
@@ -5,12 +5,14 @@ module FFaker
     extend ModuleUtils
     extend self
 
+    ROUTING_NUMBER_PREFIXES = [*'00'..'12', *'21'..'32', *'61'..'72', '80'].freeze
+
     def account_number(min_digits: 9, max_digits: 17)
       FFaker.numerify('#' * rand(min_digits..max_digits))
     end
 
     def routing_number
-      first_two_digits = fetch_sample([*'00'..'12', *'21'..'32', *'61'..'72', '80'])
+      first_two_digits = fetch_sample(ROUTING_NUMBER_PREFIXES)
 
       partial_routing_number = FFaker.numerify("#{first_two_digits}######")
       ninth_digit = generate_ninth_digit(partial_routing_number)

--- a/lib/ffaker/bank_us.rb
+++ b/lib/ffaker/bank_us.rb
@@ -10,8 +10,7 @@ module FFaker
     end
 
     def routing_number
-      first_two_digit_range = ((0..12).to_a + (21..32).to_a + (61..72).to_a + [80])
-      first_two_digits = format('%02d', first_two_digit_range.sample)
+      first_two_digits = fetch_sample([*'00'..'12', *'21'..'32', *'61'..'72', '80'])
 
       partial_routing_number = FFaker.numerify('######')
 

--- a/lib/ffaker/bank_us.rb
+++ b/lib/ffaker/bank_us.rb
@@ -12,11 +12,10 @@ module FFaker
     def routing_number
       first_two_digits = fetch_sample([*'00'..'12', *'21'..'32', *'61'..'72', '80'])
 
-      partial_routing_number = FFaker.numerify('######')
+      partial_routing_number = FFaker.numerify("#{first_two_digits}######")
+      ninth_digit = generate_ninth_digit(partial_routing_number)
 
-      ninth_digit = generate_ninth_digit(first_two_digits + partial_routing_number)
-
-      "#{first_two_digits}#{partial_routing_number}#{ninth_digit}"
+      "#{partial_routing_number}#{ninth_digit}"
     end
 
     private

--- a/lib/ffaker/bank_us.rb
+++ b/lib/ffaker/bank_us.rb
@@ -10,10 +10,14 @@ module FFaker
     end
 
     def routing_number
-      partial_routing_number = FFaker.numerify('########')
-      ninth_digit = generate_ninth_digit(partial_routing_number)
+      first_two_digit_range = ((0..12).to_a + (21..32).to_a + (61..72).to_a + [80])
+      first_two_digits = format('%02d', first_two_digit_range.sample)
 
-      "#{partial_routing_number}#{ninth_digit}"
+      partial_routing_number = FFaker.numerify('######')
+
+      ninth_digit = generate_ninth_digit(first_two_digits + partial_routing_number)
+
+      "#{first_two_digits}#{partial_routing_number}#{ninth_digit}"
     end
 
     private

--- a/test/test_bank_us.rb
+++ b/test/test_bank_us.rb
@@ -24,8 +24,7 @@ class TestBankUS < Test::Unit::TestCase
     routing_number = @tester.routing_number
     assert_match(/\A\d{9}\z/, routing_number)
 
-    first_two_digit_range = ((0..12).to_a + (21..32).to_a + (61..72).to_a + [80])
-    assert_true(first_two_digit_range.include?(routing_number[0..1].to_i))
+    assert_true(@tester::ROUTING_NUMBER_PREFIXES.include?(routing_number[0..1]))
 
     checksum = (
       (7 * (routing_number[0].to_i + routing_number[3].to_i + routing_number[6].to_i)) +

--- a/test/test_bank_us.rb
+++ b/test/test_bank_us.rb
@@ -24,6 +24,9 @@ class TestBankUS < Test::Unit::TestCase
     routing_number = @tester.routing_number
     assert_match(/\A\d{9}\z/, routing_number)
 
+    first_two_digit_range = ((0..12).to_a + (21..32).to_a + (61..72).to_a + [80])
+    assert_true(first_two_digit_range.include?(routing_number[0..1].to_i))
+
     checksum = (
       (7 * (routing_number[0].to_i + routing_number[3].to_i + routing_number[6].to_i)) +
         (3 * (routing_number[1].to_i + routing_number[4].to_i + routing_number[7].to_i)) +


### PR DESCRIPTION
Mea Culpa! I went to use `BankUS.routing_number` with our application and had 100s of test failures. Today, I learned that the first two numbers need to be within a certain range. 

Before submitting this PR, I have tested the code in my application and can confirm that there were no errors in our gazillions of tests.

----

I would like feedback on the implementation, e.g. sample.