### PR TITLE
Fix Luhn algorithm used in french companie's SIRET and sweden SSN

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1028,8 +1028,8 @@
 | Method | Example |
 | ------ | ------- |
 | `name` | Pascal, Vasseur and Mendes, Rossi et fils, Guillou-Collet |
-| `siren` | 739836110, 690890420, 300789380 |
-| `siret` | 06746846000000, 70493562000500, 45666261000350 |
+| `siren` | 739836112, 690890421, 300789385 |
+| `siret` | 06746846200006, 70493562600504 , 45666261800358 |
 | `suffix` | SA, Groupe, SARL |
 
 ## FFaker::CompanyIT

--- a/lib/ffaker/name_pl.rb
+++ b/lib/ffaker/name_pl.rb
@@ -90,9 +90,9 @@ module FFaker
 
     def name_for_gender(name_type, gender) # :nodoc:
       raise(ArgumentError, "Gender must be one of: #{GENDERS}") unless GENDERS.include?(gender)
-      return send("#{gender}_#{name_type}") unless gender == :random
+      return send(:"#{gender}_#{name_type}") unless gender == :random
 
-      fetch_sample([send("female_#{name_type}"), send("male_#{name_type}")])
+      fetch_sample([send(:"female_#{name_type}"), send(:"male_#{name_type}")])
     end
   end
 end

--- a/lib/ffaker/utils/module_utils.rb
+++ b/lib/ffaker/utils/module_utils.rb
@@ -14,7 +14,7 @@ module FFaker
 
     def const_missing(const_name)
       if const_name.match?(/[a-z]/) # Not a constant, probably a class/module name.
-        super const_name
+        super(const_name)
       else
         mod_name = ancestors.first.to_s.split('::').last
         data_path = "#{FFaker::BASE_LIB_PATH}/ffaker/data/#{underscore(mod_name)}/#{underscore(const_name.to_s)}"
@@ -43,7 +43,7 @@ module FFaker
                   .reverse
                   .each_with_index
                   .sum { |digit, index| index.even? ? (2 * digit).digits.sum : digit }
-      ((10 - sum%10)%10).to_s
+      ((10 - (sum % 10)) % 10).to_s
     end
   end
 end

--- a/lib/ffaker/utils/module_utils.rb
+++ b/lib/ffaker/utils/module_utils.rb
@@ -38,21 +38,12 @@ module FFaker
 
     # http://en.wikipedia.org/wiki/Luhn_algorithm
     def luhn_check(number)
-      multiplications = []
-
-      number.chars.each_with_index do |digit, i|
-        multiplications << i.even? ? digit.to_i * 2 : digit.to_i
-      end
-
-      sum = 0
-      multiplications.each do |num|
-        num.to_s.each_byte do |character|
-          sum += character.chr.to_i
-        end
-      end
-
-      control_digit = (sum % 10).zero? ? 0 : (((sum / 10) + 1) * 10) - sum
-      control_digit.to_s
+      sum = number.chars
+                  .map(&:to_i)
+                  .reverse
+                  .each_with_index
+                  .sum { |digit, index| index.even? ? (2 * digit).digits.sum : digit }
+      ((10 - sum%10)%10).to_s
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -35,7 +35,7 @@ module DeterministicHelper
       end
     operator_name += '_or_equal_to' if operator[1] == '='
 
-    define_method "assert_#{operator_name}" do |got, expected|
+    define_method :"assert_#{operator_name}" do |got, expected|
       assert(
         got.public_send(operator, expected),
         "Expected #{operator} \"#{expected}\", but got #{got}"
@@ -56,8 +56,8 @@ module DeterministicHelper
   end
 
   %w[less_than_or_equal_to between].each do |method_name|
-    define_method "assert_random_#{method_name}" do |*args, &block|
-      assert_random(block) { send "assert_#{method_name}", block.call, *args }
+    define_method :"assert_random_#{method_name}" do |*args, &block|
+      assert_random(block) { send :"assert_#{method_name}", block.call, *args }
     end
   end
 
@@ -76,7 +76,7 @@ module DeterministicHelper
     #  }
     def assert_methods_are_deterministic(klass, *methods)
       Array(methods).each do |meth|
-        define_method "test_#{meth}_is_deterministic" do
+        define_method :"test_#{meth}_is_deterministic" do
           assert_deterministic(message: "Results from `#{klass}.#{meth}` are not repeatable") do
             klass.send(meth)
           end

--- a/test/test_module_utils.rb
+++ b/test/test_module_utils.rb
@@ -48,9 +48,9 @@ class TestModuleUtils < Test::Unit::TestCase
   def test_luhn_check
     obj = Object.new
     obj.extend FFaker::ModuleUtils
-    assert obj.luhn_check("97248708") == "6"
-    assert obj.luhn_check("1789372997") == "4"
-    assert obj.luhn_check("8899982700037") == "1"
-    assert obj.luhn_check("1234567820001") == "0"
+    assert obj.luhn_check('97248708') == '6'
+    assert obj.luhn_check('1789372997') == '4'
+    assert obj.luhn_check('8899982700037') == '1'
+    assert obj.luhn_check('1234567820001') == '0'
   end
 end

--- a/test/test_module_utils.rb
+++ b/test/test_module_utils.rb
@@ -44,4 +44,13 @@ class TestModuleUtils < Test::Unit::TestCase
     FFaker::UniqueUtils.clear
     generator.unique.test
   end
+
+  def test_luhn_check
+    obj = Object.new
+    obj.extend FFaker::ModuleUtils
+    assert obj.luhn_check("97248708") == "6"
+    assert obj.luhn_check("1789372997") == "4"
+    assert obj.luhn_check("8899982700037") == "1"
+    assert obj.luhn_check("1234567820001") == "0"
+  end
 end


### PR DESCRIPTION
Fixed implementation for the Luhn checksum algorithm (implementation was wrong, and examples in reference where all invalid).