### PR TITLE
feat: add support for `FFaker::Boolean.boolean(true_ratio:)`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
   - Add your change HERE
   - Generator for Finnish identity numbers [@zHarrowed]
   - Fix typos and add Codespell GitHub action [@kianmeng]
+  - Add FFaker::Boolean.boolean with true ratio [@nedzib]
 
 ## 2.24.0
   - *BREAKING CHANGE*: Drop support under ruby 3.0 [@marocchino]

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -961,6 +961,7 @@
 | `maybe` | ‼️ FFaker::UniqueUtils::RetryLimitExceeded: Retry limit exceeded for maybe |
 | `random` | ‼️ FFaker::UniqueUtils::RetryLimitExceeded: Retry limit exceeded for random |
 | `sample` | ‼️ FFaker::UniqueUtils::RetryLimitExceeded: Retry limit exceeded for sample |
+| `boolean(true_ratio: 0.5)` | true, false |
 
 ## FFaker::CheesyLingo
 

--- a/lib/ffaker/boolean.rb
+++ b/lib/ffaker/boolean.rb
@@ -12,6 +12,10 @@ module FFaker
       end
     end
 
+    def boolean(true_ratio: 0.5)
+      rand < true_ratio
+    end
+
     alias random maybe
     alias sample maybe
   end

--- a/lib/ffaker/tweet.rb
+++ b/lib/ffaker/tweet.rb
@@ -19,7 +19,7 @@ module FFaker
       }.merge(args)
 
       my_reply = options[:reply] ? "#{mention} " : ''
-      my_mentions = (options[:num_mentions]).positive? ? "#{mentions(options[:num_mentions])} " : ''
+      my_mentions = options[:num_mentions].positive? ? "#{mentions(options[:num_mentions])} " : ''
       my_tags = tags(options[:num_hashtags])
 
       remaining = [

--- a/test/test_boolean.rb
+++ b/test/test_boolean.rb
@@ -5,10 +5,41 @@ require_relative 'helper'
 class TestBoolean < Test::Unit::TestCase
   include DeterministicHelper
 
-  assert_methods_are_deterministic(FFaker::Boolean, :maybe)
+  assert_methods_are_deterministic(FFaker::Boolean, :maybe, :boolean)
 
   def test_maybe
     maybe = FFaker::Boolean.maybe
     assert [true, false].include?(maybe)
+  end
+
+  def test_boolean_with_default_ratio
+    true_count = 0
+    1000.times do
+      true_count += 1 if FFaker::Boolean.boolean
+    end
+    assert_in_delta 0.5, true_count / 1000.0, 0.1
+  end
+
+  def test_boolean_with_true_ratio
+    true_ratio = 0.8
+    true_count = 0
+    1000.times do
+      true_count += 1 if FFaker::Boolean.boolean(true_ratio: true_ratio)
+    end
+    assert_in_delta true_ratio, true_count / 1000.0, 0.1
+  end
+
+  def test_boolean_with_true_ratio_zero
+    true_ratio = 0
+    100.times do
+      assert_equal false, FFaker::Boolean.boolean(true_ratio: true_ratio)
+    end
+  end
+
+  def test_boolean_with_true_ratio_one
+    true_ratio = 1
+    100.times do
+      assert_equal true, FFaker::Boolean.boolean(true_ratio: true_ratio)
+    end
   end
 end


### PR DESCRIPTION
This adds the FFaker::Boolean.boolean(true_ratio:) method.

In our use case, we need to generate seed data automatically. For some fields, it's important to bias the result toward true to better reflect real usage scenarios.

Example usage:
FFaker::Boolean.boolean(true_ratio: 0.9) → returns true ~90% of the time.

Default ratio is 0.5.

Tests included in test/test_boolean.rb.
![image](https://github.com/user-attachments/assets/9e6d7057-5f0b-4771-a2dd-5b41ff955ce4)
