### PR TITLE
Change CGI require to cgi/escape in book.rb

### DIFF
--- a/lib/ffaker/book.rb
+++ b/lib/ffaker/book.rb
@@ -2,7 +2,7 @@
 
 module FFaker
   module Book
-    require 'cgi'
+    require 'cgi/escape'
 
     extend ModuleUtils
     extend self


### PR DESCRIPTION
I've got the following error with Ruby 4.1 (unreleased):

```
/Users/okuramasafumi/.rbenv/versions/ruby-dev/lib/ruby/gems/4.1.0+1/gems/ffaker-2.25.0/lib/ffaker/book.rb:5: warning: CGI library is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
```